### PR TITLE
My Modo Configs

### DIFF
--- a/Configs/3D Gang Disabled.CFG
+++ b/Configs/3D Gang Disabled.CFG
@@ -1,0 +1,4842 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+  <atom type="Attributes">
+    <hash type="Sheet" key="66934200123:sheet">
+      <atom type="Label">Capsule</atom>
+      <atom type="Desc"></atom>
+      <atom type="Tooltip"></atom>
+      <atom type="Help"></atom>
+      <atom type="Subtext"></atom>
+      <atom type="ShowLabel">1</atom>
+      <atom type="PopupFace">option</atom>
+      <atom type="Enable">1</atom>
+      <atom type="Alignment">default</atom>
+      <atom type="Style">default</atom>
+      <atom type="Export">0</atom>
+      <atom type="Filter">58526610028:filterPreset</atom>
+      <atom type="FilterCommand"></atom>
+      <atom type="Layout">properties</atom>
+      <atom type="Justification">left</atom>
+      <atom type="Columns">1</atom>
+      <atom type="IconMode">text</atom>
+      <atom type="IconSize">small</atom>
+      <atom type="IconImage"></atom>
+      <atom type="IconResource"></atom>
+      <atom type="StartCollapsed">0</atom>
+      <atom type="EditorColor">none</atom>
+      <atom type="Proficiency">basic</atom>
+      <atom type="Group">toolprops/primitives</atom>
+      <list type="Control" val="cmd tool.apply">
+        <atom type="ShowWhenDisabled">1</atom>
+        <atom type="BooleanStyle">default</atom>
+        <atom type="Enable">1</atom>
+        <atom type="Label">Apply</atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">default</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">default</atom>
+      </list>
+      <list type="Control" val="sub 95675650344:sheet">
+        <atom type="Enable">1</atom>
+        <atom type="Label">Position 3D Gang</atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">inlinegang</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">296822640</atom>
+      </list>
+      <list type="Control" val="sub 85675650345:sheet">
+        <atom type="Enable">1</atom>
+        <atom type="Label">Position 2D Gang</atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">inlinegang</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">296822736</atom>
+      </list>
+      <list type="Control" val="sub 28533930178:sheet">
+        <atom type="Enable">1</atom>
+        <atom type="Label">Size 3D Gang</atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">inlinegang</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">296821520</atom>
+      </list>
+      <list type="Control" val="sub 38533930176:sheet">
+        <atom type="Enable">1</atom>
+        <atom type="Label">Size 2D Gang</atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">inlinegang</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">296822768</atom>
+      </list>
+      <list type="Control" val="div ">
+        <atom type="ShowWhenDisabled">1</atom>
+        <atom type="BooleanStyle">default</atom>
+        <atom type="Enable">1</atom>
+        <atom type="Label"></atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">wide</atom>
+        <atom type="Style">default</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">default</atom>
+        <atom type="Hash">{control} UID (Fri May 07 06:24:54 2004) 327980350</atom>
+      </list>
+      <list type="Control" val="cmd tool.attr prim.capsule sides ?">
+        <atom type="ShowWhenDisabled">1</atom>
+        <atom type="BooleanStyle">default</atom>
+        <atom type="Enable">1</atom>
+        <atom type="Label"></atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">default</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">default</atom>
+      </list>
+      <list type="Control" val="cmd tool.attr prim.capsule segments ?">
+        <atom type="ShowWhenDisabled">1</atom>
+        <atom type="BooleanStyle">default</atom>
+        <atom type="Enable">1</atom>
+        <atom type="Label"></atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">default</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">default</atom>
+      </list>
+      <list type="Control" val="div ">
+        <atom type="ShowWhenDisabled">1</atom>
+        <atom type="BooleanStyle">default</atom>
+        <atom type="Enable">1</atom>
+        <atom type="Label"></atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">wide</atom>
+        <atom type="Style">default</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">default</atom>
+        <atom type="Hash">{control} UID (Fri May 07 06:25:01 2004) 342168006</atom>
+      </list>
+      <list type="Control" val="cmd tool.attr prim.capsule endsegments ?">
+        <atom type="ShowWhenDisabled">1</atom>
+        <atom type="BooleanStyle">default</atom>
+        <atom type="Enable">1</atom>
+        <atom type="Label"></atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">default</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">default</atom>
+      </list>
+      <list type="Control" val="cmd tool.attr prim.capsule endsize ?">
+        <atom type="ShowWhenDisabled">1</atom>
+        <atom type="BooleanStyle">default</atom>
+        <atom type="Enable">1</atom>
+        <atom type="Label"></atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">default</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">default</atom>
+      </list>
+      <list type="Control" val="cmd tool.attr prim.capsule ends ?">
+        <atom type="ShowWhenDisabled">1</atom>
+        <atom type="BooleanStyle">default</atom>
+        <atom type="Enable">1</atom>
+        <atom type="Label"></atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">default</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">default</atom>
+      </list>
+      <list type="Control" val="cmd tool.attr prim.capsule polType ?">
+        <atom type="ShowWhenDisabled">1</atom>
+        <atom type="BooleanStyle">default</atom>
+        <atom type="Enable">1</atom>
+        <atom type="Label"></atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">default</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">default</atom>
+      </list>
+      <list type="Control" val="div ">
+        <atom type="ShowWhenDisabled">1</atom>
+        <atom type="BooleanStyle">default</atom>
+        <atom type="Enable">1</atom>
+        <atom type="Label"></atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">wide</atom>
+        <atom type="Style">default</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">default</atom>
+        <atom type="Hash">{control} UID (Fri May 07 06:25:05 2004) 350148825</atom>
+      </list>
+      <list type="Control" val="cmd tool.attr prim.capsule axis ?">
+        <atom type="ShowWhenDisabled">1</atom>
+        <atom type="BooleanStyle">default</atom>
+        <atom type="Enable">1</atom>
+        <atom type="Label"></atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">default</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">default</atom>
+      </list>
+      <list type="Control" val="cmd tool.attr prim.capsule uvs ?">
+        <atom type="ShowWhenDisabled">1</atom>
+        <atom type="BooleanStyle">default</atom>
+        <atom type="Enable">1</atom>
+        <atom type="Label"></atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">default</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">default</atom>
+      </list>
+      <list type="Control" val="div ">
+        <atom type="ShowWhenDisabled">1</atom>
+        <atom type="BooleanStyle">default</atom>
+        <atom type="Enable">1</atom>
+        <atom type="Label"></atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">wide</atom>
+        <atom type="Style">default</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">default</atom>
+        <atom type="Hash">{control} UID (Fri May 07 07:11:58 2004) 357899846</atom>
+      </list>
+      <list type="Control" val="cmd tool.attr prim.capsule handleMode ?">
+        <atom type="ShowWhenDisabled">1</atom>
+        <atom type="BooleanStyle">default</atom>
+        <atom type="Enable">1</atom>
+        <atom type="Label">Handle Mode</atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">default</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">default</atom>
+      </list>
+      <list type="Control" val="cmd tool.attr prim.capsule showCorner ?">
+        <atom type="ShowWhenDisabled">1</atom>
+        <atom type="BooleanStyle">default</atom>
+        <atom type="Enable">1</atom>
+        <atom type="Label">Show Corner</atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">default</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">default</atom>
+      </list>
+      <list type="Control" val="div ">
+        <atom type="ShowWhenDisabled">1</atom>
+        <atom type="BooleanStyle">default</atom>
+        <atom type="Enable">1</atom>
+        <atom type="Label"></atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">wide</atom>
+        <atom type="Style">default</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">default</atom>
+        <atom type="Hash">24081077426:control</atom>
+      </list>
+      <list type="Control" val="sub 47620687069:sheet">
+        <atom type="Enable">0</atom>
+        <atom type="Label">Min 3D Gang</atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">inlinegang</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">296822320</atom>
+      </list>
+      <list type="Control" val="sub 77620684469:sheet">
+        <atom type="Enable">1</atom>
+        <atom type="Label">Min 2D Gang</atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">inlinegang</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">296824592</atom>
+      </list>
+      <list type="Control" val="sub 18156687073:sheet">
+        <atom type="Enable">0</atom>
+        <atom type="Label">Max 3D Gang</atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">inlinegang</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">296821168</atom>
+      </list>
+      <list type="Control" val="sub 58156687673:sheet">
+        <atom type="Enable">0</atom>
+        <atom type="Label">Max 3D Gang</atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">inlinegang</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">296822096</atom>
+      </list>
+      <list type="Control" val="div ">
+        <atom type="ShowWhenDisabled">1</atom>
+        <atom type="BooleanStyle">default</atom>
+        <atom type="Enable">1</atom>
+        <atom type="Label"></atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">wide</atom>
+        <atom type="Style">default</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">default</atom>
+        <atom type="Hash">{control} UID (Fri May 07 07:11:58 2004) 357899846</atom>
+      </list>
+      <hash type="InCategory" key="toolprops:main#head">
+        <atom type="Ordinal">150.65</atom>
+      </hash>
+    </hash>
+    <hash type="Sheet" key="71343990066:sheet">
+      <atom type="Label">Cone</atom>
+      <atom type="Desc"></atom>
+      <atom type="Tooltip"></atom>
+      <atom type="Help"></atom>
+      <atom type="Subtext"></atom>
+      <atom type="ShowLabel">1</atom>
+      <atom type="PopupFace">option</atom>
+      <atom type="Enable">1</atom>
+      <atom type="Alignment">default</atom>
+      <atom type="Style">default</atom>
+      <atom type="Export">0</atom>
+      <atom type="Filter">84072870136:filterPreset</atom>
+      <atom type="FilterCommand"></atom>
+      <atom type="Layout">properties</atom>
+      <atom type="Justification">left</atom>
+      <atom type="Columns">1</atom>
+      <atom type="IconMode">text</atom>
+      <atom type="IconSize">small</atom>
+      <atom type="IconImage"></atom>
+      <atom type="IconResource"></atom>
+      <atom type="StartCollapsed">0</atom>
+      <atom type="EditorColor">none</atom>
+      <atom type="Proficiency">basic</atom>
+      <atom type="Group">toolprops/primitives</atom>
+      <list type="Control" val="cmd tool.apply">
+        <atom type="ShowWhenDisabled">1</atom>
+        <atom type="BooleanStyle">default</atom>
+        <atom type="Enable">1</atom>
+        <atom type="Label">Apply</atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">default</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">default</atom>
+      </list>
+      <list type="Control" val="sub 87704460214:sheet">
+        <atom type="Enable">1</atom>
+        <atom type="Label">Position 3D Gang</atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">inlinegang</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">296817040</atom>
+      </list>
+      <list type="Control" val="sub 97704460213:sheet">
+        <atom type="Enable">1</atom>
+        <atom type="Label">Position 2D Gang</atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">inlinegang</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">296818480</atom>
+      </list>
+      <list type="Control" val="sub 03039550177:sheet">
+        <atom type="Enable">1</atom>
+        <atom type="Label">Size 3D Gang</atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">inlinegang</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">296818992</atom>
+      </list>
+      <list type="Control" val="sub 23039550173:sheet">
+        <atom type="Enable">1</atom>
+        <atom type="Label">Size 2D Gang</atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">inlinegang</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">296819952</atom>
+      </list>
+      <list type="Control" val="div ">
+        <atom type="ShowWhenDisabled">1</atom>
+        <atom type="BooleanStyle">default</atom>
+        <atom type="Enable">1</atom>
+        <atom type="Label"></atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">wide</atom>
+        <atom type="Style">default</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">default</atom>
+        <atom type="Hash">{control} UID (Fri May 07 06:23:46 2004) 184527381</atom>
+      </list>
+      <list type="Control" val="cmd tool.attr prim.cone sides ?">
+        <atom type="ShowWhenDisabled">1</atom>
+        <atom type="BooleanStyle">default</atom>
+        <atom type="Enable">1</atom>
+        <atom type="Label"></atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">default</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">default</atom>
+      </list>
+      <list type="Control" val="cmd tool.attr prim.cone segments ?">
+        <atom type="ShowWhenDisabled">1</atom>
+        <atom type="BooleanStyle">default</atom>
+        <atom type="Enable">1</atom>
+        <atom type="Label"></atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">default</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">default</atom>
+      </list>
+      <list type="Control" val="cmd tool.attr prim.cone polType ?">
+        <atom type="ShowWhenDisabled">1</atom>
+        <atom type="BooleanStyle">default</atom>
+        <atom type="Enable">1</atom>
+        <atom type="Label"></atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">default</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">default</atom>
+      </list>
+      <list type="Control" val="cmd tool.attr prim.cone capBottom ?">
+        <atom type="ShowWhenDisabled">1</atom>
+        <atom type="BooleanStyle">default</atom>
+        <atom type="Enable">1</atom>
+        <atom type="Label"></atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">default</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">default</atom>
+      </list>
+      <list type="Control" val="cmd tool.attr prim.cone edgeWeight ?">
+        <atom type="ShowWhenDisabled">1</atom>
+        <atom type="BooleanStyle">default</atom>
+        <atom type="Enable">1</atom>
+        <atom type="Label"></atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">default</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">default</atom>
+      </list>
+      <list type="Control" val="div ">
+        <atom type="ShowWhenDisabled">1</atom>
+        <atom type="BooleanStyle">default</atom>
+        <atom type="Enable">1</atom>
+        <atom type="Label"></atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">wide</atom>
+        <atom type="Style">default</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">default</atom>
+        <atom type="Hash">{control} UID (Fri May 07 06:23:44 2004) 180685154</atom>
+      </list>
+      <list type="Control" val="cmd tool.attr prim.cone axis ?">
+        <atom type="ShowWhenDisabled">1</atom>
+        <atom type="BooleanStyle">default</atom>
+        <atom type="Enable">1</atom>
+        <atom type="Label"></atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">default</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">default</atom>
+      </list>
+      <list type="Control" val="cmd tool.attr prim.cone uvs ?">
+        <atom type="ShowWhenDisabled">1</atom>
+        <atom type="BooleanStyle">default</atom>
+        <atom type="Enable">1</atom>
+        <atom type="Label"></atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">default</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">default</atom>
+      </list>
+      <list type="Control" val="div ">
+        <atom type="ShowWhenDisabled">1</atom>
+        <atom type="BooleanStyle">default</atom>
+        <atom type="Enable">1</atom>
+        <atom type="Label"></atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">wide</atom>
+        <atom type="Style">default</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">default</atom>
+        <atom type="Hash">{control} UID (Fri May 07 07:11:58 2004) 357899846</atom>
+      </list>
+      <list type="Control" val="cmd tool.attr prim.cone handleMode ?">
+        <atom type="ShowWhenDisabled">1</atom>
+        <atom type="BooleanStyle">default</atom>
+        <atom type="Enable">1</atom>
+        <atom type="Label">Handle Mode</atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">default</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">default</atom>
+      </list>
+      <list type="Control" val="cmd tool.attr prim.cone showCorner ?">
+        <atom type="ShowWhenDisabled">1</atom>
+        <atom type="BooleanStyle">default</atom>
+        <atom type="Enable">1</atom>
+        <atom type="Label">Show Corner</atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">default</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">default</atom>
+      </list>
+      <list type="Control" val="div ">
+        <atom type="ShowWhenDisabled">1</atom>
+        <atom type="BooleanStyle">default</atom>
+        <atom type="Enable">1</atom>
+        <atom type="Label"></atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">wide</atom>
+        <atom type="Style">default</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">default</atom>
+        <atom type="Hash">23081077426:control</atom>
+      </list>
+      <list type="Control" val="sub 49229682354:sheet">
+        <atom type="Enable">0</atom>
+        <atom type="Label">Min 3D Gang</atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">inlinegang</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">296817936</atom>
+      </list>
+      <list type="Control" val="sub 59229682353:sheet">
+        <atom type="Enable">1</atom>
+        <atom type="Label">Min 2D Gang</atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">inlinegang</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">296818384</atom>
+      </list>
+      <list type="Control" val="sub 96063682330:sheet">
+        <atom type="Enable">0</atom>
+        <atom type="Label">Max 3D Gang</atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">inlinegang</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">296817456</atom>
+      </list>
+      <list type="Control" val="sub 76063682336:sheet">
+        <atom type="Enable">1</atom>
+        <atom type="Label">Max 2D Gang</atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">inlinegang</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">296817968</atom>
+      </list>
+      <list type="Control" val="div ">
+        <atom type="ShowWhenDisabled">1</atom>
+        <atom type="BooleanStyle">default</atom>
+        <atom type="Enable">1</atom>
+        <atom type="Label"></atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">wide</atom>
+        <atom type="Style">default</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">default</atom>
+        <atom type="Hash">70833682365:control</atom>
+      </list>
+      <hash type="InCategory" key="toolprops:main#head">
+        <atom type="Ordinal">150.60</atom>
+      </hash>
+    </hash>
+    <hash type="Sheet" key="15515130155:sheet">
+      <atom type="Label">Cube</atom>
+      <atom type="Desc"></atom>
+      <atom type="Tooltip"></atom>
+      <atom type="Help"></atom>
+      <atom type="Subtext"></atom>
+      <atom type="ShowLabel">1</atom>
+      <atom type="PopupFace">option</atom>
+      <atom type="Enable">1</atom>
+      <atom type="Alignment">default</atom>
+      <atom type="Style">default</atom>
+      <atom type="Export">0</atom>
+      <atom type="Filter">28985590035:filterPreset</atom>
+      <atom type="FilterCommand"></atom>
+      <atom type="Layout">properties</atom>
+      <atom type="Justification">left</atom>
+      <atom type="Columns">1</atom>
+      <atom type="IconMode">text</atom>
+      <atom type="IconSize">small</atom>
+      <atom type="IconImage"></atom>
+      <atom type="IconResource"></atom>
+      <atom type="StartCollapsed">0</atom>
+      <atom type="EditorColor">none</atom>
+      <atom type="Proficiency">basic</atom>
+      <atom type="Group">toolprops/primitives</atom>
+      <list type="Control" val="cmd tool.apply">
+        <atom type="ShowWhenDisabled">1</atom>
+        <atom type="BooleanStyle">default</atom>
+        <atom type="Enable">1</atom>
+        <atom type="Label">Apply</atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">default</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">default</atom>
+      </list>
+      <list type="Control" val="sub 24301140007:sheet">
+        <atom type="Enable">1</atom>
+        <atom type="Label">Position 3D Gang</atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">inlinegang</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">296003344</atom>
+      </list>
+      <list type="Control" val="sub 14301140008:sheet">
+        <atom type="Enable">1</atom>
+        <atom type="Label">Position 2D Gang</atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">inlinegang</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">296004272</atom>
+      </list>
+      <list type="Control" val="sub 50332640366:sheet">
+        <atom type="Enable">1</atom>
+        <atom type="Label">Size 3D Gang</atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">inlinegang</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">296005552</atom>
+      </list>
+      <list type="Control" val="sub 40332640367:sheet">
+        <atom type="Enable">1</atom>
+        <atom type="Label">Size 2D Gang</atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">inlinegang</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">296005872</atom>
+      </list>
+      <list type="Control" val="sub 48712150064:sheet">
+        <atom type="Enable">1</atom>
+        <atom type="Label">Segments 3D Gang</atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">inlinegang</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">296004144</atom>
+      </list>
+      <list type="Control" val="sub 38712150065:sheet">
+        <atom type="Enable">1</atom>
+        <atom type="Label">Segments 2D Gang</atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">inlinegang</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">296005456</atom>
+      </list>
+      <list type="Control" val="div ">
+        <atom type="ShowWhenDisabled">1</atom>
+        <atom type="BooleanStyle">default</atom>
+        <atom type="Enable">1</atom>
+        <atom type="Label"></atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">wide</atom>
+        <atom type="Style">default</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">default</atom>
+        <atom type="Hash">{control} UID (Fri May 07 06:13:55 2004) 284004697</atom>
+      </list>
+      <list type="Control" val="cmd tool.attr prim.cube radius ?">
+        <atom type="ShowWhenDisabled">1</atom>
+        <atom type="BooleanStyle">default</atom>
+        <atom type="Enable">1</atom>
+        <atom type="Label"></atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">default</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">default</atom>
+      </list>
+      <list type="Control" val="cmd tool.attr prim.cube segmentsR ?">
+        <atom type="ShowWhenDisabled">1</atom>
+        <atom type="BooleanStyle">default</atom>
+        <atom type="Enable">1</atom>
+        <atom type="Label"></atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">default</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">default</atom>
+      </list>
+      <list type="Control" val="cmd tool.attr prim.cube sharp ?">
+        <atom type="ShowWhenDisabled">1</atom>
+        <atom type="BooleanStyle">default</atom>
+        <atom type="Enable">1</atom>
+        <atom type="Label"></atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">default</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">default</atom>
+      </list>
+      <list type="Control" val="div ">
+        <atom type="ShowWhenDisabled">1</atom>
+        <atom type="BooleanStyle">default</atom>
+        <atom type="Enable">1</atom>
+        <atom type="Label"></atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">wide</atom>
+        <atom type="Style">default</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">default</atom>
+        <atom type="Hash">{control} UID (Fri May 07 06:14:07 2004) 309653877</atom>
+      </list>
+      <list type="Control" val="cmd tool.attr prim.cube axis ?">
+        <atom type="ShowWhenDisabled">1</atom>
+        <atom type="BooleanStyle">default</atom>
+        <atom type="Enable">1</atom>
+        <atom type="Label"></atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">default</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">default</atom>
+      </list>
+      <list type="Control" val="cmd tool.attr prim.cube uvs ?">
+        <atom type="ShowWhenDisabled">1</atom>
+        <atom type="BooleanStyle">default</atom>
+        <atom type="Enable">1</atom>
+        <atom type="Label"></atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">default</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">default</atom>
+      </list>
+      <list type="Control" val="div ">
+        <atom type="ShowWhenDisabled">1</atom>
+        <atom type="BooleanStyle">default</atom>
+        <atom type="Enable">1</atom>
+        <atom type="Label"></atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">wide</atom>
+        <atom type="Style">default</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">default</atom>
+        <atom type="Hash">{control} UID (Fri May 07 07:11:58 2004) 357899846</atom>
+      </list>
+      <list type="Control" val="cmd tool.attr prim.cube handleMode ?">
+        <atom type="ShowWhenDisabled">1</atom>
+        <atom type="BooleanStyle">default</atom>
+        <atom type="Enable">1</atom>
+        <atom type="Label">Handle Mode</atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">default</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">default</atom>
+      </list>
+      <list type="Control" val="cmd tool.attr prim.cube showCorner ?">
+        <atom type="ShowWhenDisabled">1</atom>
+        <atom type="BooleanStyle">default</atom>
+        <atom type="Enable">1</atom>
+        <atom type="Label">Show Corner</atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">default</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">default</atom>
+      </list>
+      <list type="Control" val="div ">
+        <atom type="ShowWhenDisabled">1</atom>
+        <atom type="BooleanStyle">default</atom>
+        <atom type="Enable">1</atom>
+        <atom type="Label"></atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">wide</atom>
+        <atom type="Style">default</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">default</atom>
+        <atom type="Hash">20081077426:control</atom>
+      </list>
+      <list type="Control" val="sub 81695690753:sheet">
+        <atom type="Enable">0</atom>
+        <atom type="Label">Min 3D Gang</atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">inlinegang</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">296005264</atom>
+      </list>
+      <list type="Control" val="sub 91695690752:sheet">
+        <atom type="Enable">1</atom>
+        <atom type="Label">Min 2D Gang</atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">inlinegang</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">296007312</atom>
+      </list>
+      <list type="Control" val="sub 10630690757:sheet">
+        <atom type="Enable">0</atom>
+        <atom type="Label">Max 3D Gang</atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">inlinegang</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">296004656</atom>
+      </list>
+      <list type="Control" val="sub 90630690756:sheet">
+        <atom type="Enable">1</atom>
+        <atom type="Label">Max 2D Gang</atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">inlinegang</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">296005712</atom>
+      </list>
+      <list type="Control" val="div ">
+        <atom type="ShowWhenDisabled">1</atom>
+        <atom type="BooleanStyle">default</atom>
+        <atom type="Enable">1</atom>
+        <atom type="Label"></atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">wide</atom>
+        <atom type="Style">default</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">default</atom>
+        <atom type="Hash">{control} UID (Fri May 07 07:11:58 2004) 357899846</atom>
+      </list>
+      <hash type="InCategory" key="toolprops:main#head">
+        <atom type="Ordinal">150.45</atom>
+      </hash>
+    </hash>
+    <hash type="Sheet" key="03106680311:sheet">
+      <atom type="Label">Cylinder</atom>
+      <atom type="Desc"></atom>
+      <atom type="Tooltip"></atom>
+      <atom type="Help"></atom>
+      <atom type="Subtext"></atom>
+      <atom type="ShowLabel">1</atom>
+      <atom type="PopupFace">option</atom>
+      <atom type="Enable">1</atom>
+      <atom type="Alignment">default</atom>
+      <atom type="Style">default</atom>
+      <atom type="Export">0</atom>
+      <atom type="Filter">41705320101:filterPreset</atom>
+      <atom type="FilterCommand"></atom>
+      <atom type="Layout">properties</atom>
+      <atom type="Justification">left</atom>
+      <atom type="Columns">1</atom>
+      <atom type="IconMode">text</atom>
+      <atom type="IconSize">small</atom>
+      <atom type="IconImage"></atom>
+      <atom type="IconResource"></atom>
+      <atom type="StartCollapsed">0</atom>
+      <atom type="EditorColor">none</atom>
+      <atom type="Proficiency">basic</atom>
+      <atom type="Group">toolprops/primitives</atom>
+      <list type="Control" val="cmd tool.apply">
+        <atom type="ShowWhenDisabled">1</atom>
+        <atom type="BooleanStyle">default</atom>
+        <atom type="Enable">1</atom>
+        <atom type="Label">Apply</atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">default</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">default</atom>
+      </list>
+      <list type="Control" val="sub 00021360043:sheet">
+        <atom type="Enable">1</atom>
+        <atom type="Label">Position 3D Gang</atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">inlinegang</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">296814544</atom>
+      </list>
+      <list type="Control" val="sub 10021360042:sheet">
+        <atom type="Enable">1</atom>
+        <atom type="Label">Position 2D Gang</atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">inlinegang</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">296814864</atom>
+      </list>
+      <list type="Control" val="sub 74108880287:sheet">
+        <atom type="Enable">1</atom>
+        <atom type="Label">Size 3D Gang</atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">inlinegang</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">296815792</atom>
+      </list>
+      <list type="Control" val="sub 84108880286:sheet">
+        <atom type="Enable">1</atom>
+        <atom type="Label">Size 2D Gang</atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">inlinegang</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">296815824</atom>
+      </list>
+      <list type="Control" val="div ">
+        <atom type="ShowWhenDisabled">1</atom>
+        <atom type="BooleanStyle">default</atom>
+        <atom type="Enable">1</atom>
+        <atom type="Label"></atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">wide</atom>
+        <atom type="Style">default</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">default</atom>
+        <atom type="Hash">{control} UID (Fri May 07 06:21:06 2004) 385066765</atom>
+      </list>
+      <list type="Control" val="cmd tool.attr prim.cylinder sides ?">
+        <atom type="ShowWhenDisabled">1</atom>
+        <atom type="BooleanStyle">default</atom>
+        <atom type="Enable">1</atom>
+        <atom type="Label"></atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">default</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">default</atom>
+      </list>
+      <list type="Control" val="cmd tool.attr prim.cylinder segments ?">
+        <atom type="ShowWhenDisabled">1</atom>
+        <atom type="BooleanStyle">default</atom>
+        <atom type="Enable">1</atom>
+        <atom type="Label"></atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">default</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">default</atom>
+      </list>
+      <list type="Control" val="cmd tool.attr prim.cylinder polType ?">
+        <atom type="ShowWhenDisabled">1</atom>
+        <atom type="BooleanStyle">default</atom>
+        <atom type="Enable">1</atom>
+        <atom type="Label"></atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">default</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">default</atom>
+      </list>
+      <list type="Control" val="cmd tool.attr prim.cylinder capTop ?">
+        <atom type="ShowWhenDisabled">1</atom>
+        <atom type="BooleanStyle">default</atom>
+        <atom type="Enable">1</atom>
+        <atom type="Label"></atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">default</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">default</atom>
+      </list>
+      <list type="Control" val="cmd tool.attr prim.cylinder capBottom ?">
+        <atom type="ShowWhenDisabled">1</atom>
+        <atom type="BooleanStyle">default</atom>
+        <atom type="Enable">1</atom>
+        <atom type="Label"></atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">default</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">default</atom>
+      </list>
+      <list type="Control" val="cmd tool.attr prim.cylinder edgeWeight ?">
+        <atom type="ShowWhenDisabled">1</atom>
+        <atom type="BooleanStyle">default</atom>
+        <atom type="Enable">1</atom>
+        <atom type="Label"></atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">default</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">default</atom>
+      </list>
+      <list type="Control" val="div ">
+        <atom type="ShowWhenDisabled">1</atom>
+        <atom type="BooleanStyle">default</atom>
+        <atom type="Enable">1</atom>
+        <atom type="Label"></atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">wide</atom>
+        <atom type="Style">default</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">default</atom>
+        <atom type="Hash">{control} UID (Fri May 07 06:21:04 2004) 381190907</atom>
+      </list>
+      <list type="Control" val="cmd tool.attr prim.cylinder axis ?">
+        <atom type="ShowWhenDisabled">1</atom>
+        <atom type="BooleanStyle">default</atom>
+        <atom type="Enable">1</atom>
+        <atom type="Label"></atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">default</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">default</atom>
+      </list>
+      <list type="Control" val="cmd tool.attr prim.cylinder uvs ?">
+        <atom type="ShowWhenDisabled">1</atom>
+        <atom type="BooleanStyle">default</atom>
+        <atom type="Enable">1</atom>
+        <atom type="Label"></atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">default</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">default</atom>
+      </list>
+      <list type="Control" val="div ">
+        <atom type="ShowWhenDisabled">1</atom>
+        <atom type="BooleanStyle">default</atom>
+        <atom type="Enable">1</atom>
+        <atom type="Label"></atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">wide</atom>
+        <atom type="Style">default</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">default</atom>
+        <atom type="Hash">{control} UID (Fri May 07 07:11:58 2004) 357899846</atom>
+      </list>
+      <list type="Control" val="cmd tool.attr prim.cylinder handleMode ?">
+        <atom type="ShowWhenDisabled">1</atom>
+        <atom type="BooleanStyle">default</atom>
+        <atom type="Enable">1</atom>
+        <atom type="Label">Handle Mode</atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">default</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">default</atom>
+      </list>
+      <list type="Control" val="cmd tool.attr prim.cylinder showCorner ?">
+        <atom type="ShowWhenDisabled">1</atom>
+        <atom type="BooleanStyle">default</atom>
+        <atom type="Enable">1</atom>
+        <atom type="Label">Show Corner</atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">default</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">default</atom>
+      </list>
+      <list type="Control" val="div ">
+        <atom type="ShowWhenDisabled">1</atom>
+        <atom type="BooleanStyle">default</atom>
+        <atom type="Enable">1</atom>
+        <atom type="Label"></atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">wide</atom>
+        <atom type="Style">default</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">default</atom>
+        <atom type="Hash">22081077426:control</atom>
+      </list>
+      <list type="Control" val="sub 11354086257:sheet">
+        <atom type="Enable">0</atom>
+        <atom type="Label">Min 3D Gang</atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">inlinegang</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">296814064</atom>
+      </list>
+      <list type="Control" val="sub 21354086256:sheet">
+        <atom type="Enable">1</atom>
+        <atom type="Label">Min 2D Gang</atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">inlinegang</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">296814128</atom>
+      </list>
+      <list type="Control" val="sub 35727086441:sheet">
+        <atom type="Enable">0</atom>
+        <atom type="Label">Max 3D Gang</atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">inlinegang</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">296813072</atom>
+      </list>
+      <list type="Control" val="sub 75727086451:sheet">
+        <atom type="Enable">1</atom>
+        <atom type="Label">Max 2D Gang</atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">inlinegang</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">296813168</atom>
+      </list>
+      <list type="Control" val="div ">
+        <atom type="ShowWhenDisabled">1</atom>
+        <atom type="BooleanStyle">default</atom>
+        <atom type="Enable">1</atom>
+        <atom type="Label"></atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">wide</atom>
+        <atom type="Style">default</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">default</atom>
+        <atom type="Hash">69866078321:control</atom>
+      </list>
+      <hash type="InCategory" key="toolprops:main#head">
+        <atom type="Ordinal">150.55</atom>
+      </hash>
+    </hash>
+    <hash type="Sheet" key="01181030223:sheet">
+      <atom type="Label">Ellipsoid</atom>
+      <atom type="Desc"></atom>
+      <atom type="Tooltip"></atom>
+      <atom type="Help"></atom>
+      <atom type="Subtext"></atom>
+      <atom type="ShowLabel">1</atom>
+      <atom type="PopupFace">option</atom>
+      <atom type="Enable">1</atom>
+      <atom type="Alignment">default</atom>
+      <atom type="Style">default</atom>
+      <atom type="Export">0</atom>
+      <atom type="Filter">58786010111:filterPreset</atom>
+      <atom type="FilterCommand"></atom>
+      <atom type="Layout">properties</atom>
+      <atom type="Justification">left</atom>
+      <atom type="Columns">1</atom>
+      <atom type="IconMode">text</atom>
+      <atom type="IconSize">small</atom>
+      <atom type="IconImage"></atom>
+      <atom type="IconResource"></atom>
+      <atom type="StartCollapsed">0</atom>
+      <atom type="EditorColor">none</atom>
+      <atom type="Proficiency">basic</atom>
+      <atom type="Group">toolprops/primitives</atom>
+      <list type="Control" val="cmd tool.apply">
+        <atom type="ShowWhenDisabled">1</atom>
+        <atom type="BooleanStyle">default</atom>
+        <atom type="Enable">1</atom>
+        <atom type="Label">Apply</atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">default</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">default</atom>
+      </list>
+      <list type="Control" val="sub 58450310286:sheet">
+        <atom type="Enable">1</atom>
+        <atom type="Label">Position 3D Gang</atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">inlinegang</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">296832080</atom>
+      </list>
+      <list type="Control" val="sub 97450310286:sheet">
+        <atom type="Enable">1</atom>
+        <atom type="Label">Position 2D Gang</atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">inlinegang</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">296832688</atom>
+      </list>
+      <list type="Control" val="sub 98654170055:sheet">
+        <atom type="Enable">1</atom>
+        <atom type="Label">Size 3D Gang</atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">inlinegang</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">296831568</atom>
+      </list>
+      <list type="Control" val="sub 68654170055:sheet">
+        <atom type="Enable">1</atom>
+        <atom type="Label">Size 2D Gang</atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">inlinegang</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">296833744</atom>
+      </list>
+      <list type="Control" val="div ">
+        <atom type="ShowWhenDisabled">1</atom>
+        <atom type="BooleanStyle">default</atom>
+        <atom type="Enable">1</atom>
+        <atom type="Label"></atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">wide</atom>
+        <atom type="Style">default</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">default</atom>
+        <atom type="Hash">{control} UID (Fri May 07 07:01:32 2004) 383578229</atom>
+      </list>
+      <list type="Control" val="cmd tool.attr prim.ellipsoid sides ?">
+        <atom type="ShowWhenDisabled">1</atom>
+        <atom type="BooleanStyle">default</atom>
+        <atom type="Enable">1</atom>
+        <atom type="Label"></atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">default</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">default</atom>
+      </list>
+      <list type="Control" val="cmd tool.attr prim.ellipsoid segments ?">
+        <atom type="ShowWhenDisabled">1</atom>
+        <atom type="BooleanStyle">default</atom>
+        <atom type="Enable">1</atom>
+        <atom type="Label"></atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">default</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">default</atom>
+      </list>
+      <list type="Control" val="cmd tool.attr prim.ellipsoid polType ?">
+        <atom type="ShowWhenDisabled">1</atom>
+        <atom type="BooleanStyle">default</atom>
+        <atom type="Enable">1</atom>
+        <atom type="Label"></atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">default</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">default</atom>
+      </list>
+      <list type="Control" val="div ">
+        <atom type="ShowWhenDisabled">1</atom>
+        <atom type="BooleanStyle">default</atom>
+        <atom type="Enable">1</atom>
+        <atom type="Label"></atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">wide</atom>
+        <atom type="Style">default</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">default</atom>
+        <atom type="Hash">{control} UID (Fri May 07 07:01:28 2004) 375303147</atom>
+      </list>
+      <list type="Control" val="sub 96908560006:sheet">
+        <atom type="Enable">1</atom>
+        <atom type="Label">Bulge Gang</atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">inlinegang</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">296833808</atom>
+      </list>
+      <list type="Control" val="div ">
+        <atom type="ShowWhenDisabled">1</atom>
+        <atom type="BooleanStyle">default</atom>
+        <atom type="Enable">1</atom>
+        <atom type="Label"></atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">wide</atom>
+        <atom type="Style">default</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">default</atom>
+        <atom type="Hash">{control} UID (Fri May 07 07:01:37 2004) 394777019</atom>
+      </list>
+      <list type="Control" val="cmd tool.attr prim.ellipsoid axis ?">
+        <atom type="ShowWhenDisabled">1</atom>
+        <atom type="BooleanStyle">default</atom>
+        <atom type="Enable">1</atom>
+        <atom type="Label"></atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">default</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">default</atom>
+      </list>
+      <list type="Control" val="cmd tool.attr prim.ellipsoid uvs ?">
+        <atom type="ShowWhenDisabled">1</atom>
+        <atom type="BooleanStyle">default</atom>
+        <atom type="Enable">1</atom>
+        <atom type="Label"></atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">default</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">default</atom>
+      </list>
+      <list type="Control" val="div ">
+        <atom type="ShowWhenDisabled">1</atom>
+        <atom type="BooleanStyle">default</atom>
+        <atom type="Enable">1</atom>
+        <atom type="Label"></atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">wide</atom>
+        <atom type="Style">default</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">default</atom>
+        <atom type="Hash">{control} UID (Fri May 07 07:11:58 2004) 357899846</atom>
+      </list>
+      <list type="Control" val="cmd tool.attr prim.ellipsoid handleMode ?">
+        <atom type="ShowWhenDisabled">1</atom>
+        <atom type="BooleanStyle">default</atom>
+        <atom type="Enable">1</atom>
+        <atom type="Label">Handle Mode</atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">default</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">default</atom>
+      </list>
+      <list type="Control" val="cmd tool.attr prim.ellipsoid showCorner ?">
+        <atom type="ShowWhenDisabled">1</atom>
+        <atom type="BooleanStyle">default</atom>
+        <atom type="Enable">1</atom>
+        <atom type="Label">Show Corner</atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">default</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">default</atom>
+      </list>
+      <list type="Control" val="div ">
+        <atom type="ShowWhenDisabled">1</atom>
+        <atom type="BooleanStyle">default</atom>
+        <atom type="Enable">1</atom>
+        <atom type="Label"></atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">wide</atom>
+        <atom type="Style">default</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">default</atom>
+        <atom type="Hash">25081077426:control</atom>
+      </list>
+      <list type="Control" val="sub 86631686305:sheet">
+        <atom type="Enable">0</atom>
+        <atom type="Label">Min 3D Gang</atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">inlinegang</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">296835344</atom>
+      </list>
+      <list type="Control" val="sub 66631686305:sheet">
+        <atom type="Enable">1</atom>
+        <atom type="Label">Min 2D Gang</atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">inlinegang</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">296834768</atom>
+      </list>
+      <list type="Control" val="sub 51037686309:sheet">
+        <atom type="Enable">0</atom>
+        <atom type="Label">Max 3D Gang</atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">inlinegang</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">296833488</atom>
+      </list>
+      <list type="Control" val="sub 44037686309:sheet">
+        <atom type="Enable">1</atom>
+        <atom type="Label">Max 2D Gang</atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">inlinegang</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">296833520</atom>
+      </list>
+      <list type="Control" val="div ">
+        <atom type="ShowWhenDisabled">1</atom>
+        <atom type="BooleanStyle">default</atom>
+        <atom type="Enable">1</atom>
+        <atom type="Label"></atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">wide</atom>
+        <atom type="Style">default</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">default</atom>
+        <atom type="Hash">{control} UID (Fri May 07 07:11:58 2004) 357899846</atom>
+      </list>
+      <hash type="InCategory" key="toolprops:main#head">
+        <atom type="Ordinal">150.90</atom>
+      </hash>
+    </hash>
+    <hash type="Sheet" key="10630690757:sheet">
+      <atom type="Label">Max 3D Gang</atom>
+      <atom type="Desc"></atom>
+      <atom type="Tooltip"></atom>
+      <atom type="Help"></atom>
+      <atom type="Subtext"></atom>
+      <atom type="ShowLabel">1</atom>
+      <atom type="PopupFace">option</atom>
+      <atom type="Enable">0</atom>
+      <atom type="Alignment">default</atom>
+      <atom type="Style">inlinegang</atom>
+      <atom type="Export">0</atom>
+      <atom type="Filter">ViewType: 3D mode</atom>
+      <atom type="FilterCommand"></atom>
+      <atom type="Layout">properties</atom>
+      <atom type="Justification">left</atom>
+      <atom type="Columns">1</atom>
+      <atom type="IconMode">text</atom>
+      <atom type="IconSize">small</atom>
+      <atom type="IconImage"></atom>
+      <atom type="IconResource"></atom>
+      <atom type="StartCollapsed">0</atom>
+      <atom type="EditorColor">none</atom>
+      <atom type="Proficiency">basic</atom>
+      <atom type="Group"></atom>
+      <list type="Control" val="cmd tool.attr prim.cube maxX ?">
+        <atom type="ShowWhenDisabled">1</atom>
+        <atom type="BooleanStyle">default</atom>
+        <atom type="Enable">1</atom>
+        <atom type="Label">Max X</atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">default</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">default</atom>
+      </list>
+      <list type="Control" val="cmd tool.attr prim.cube maxY ?">
+        <atom type="ShowWhenDisabled">1</atom>
+        <atom type="BooleanStyle">default</atom>
+        <atom type="Enable">1</atom>
+        <atom type="Label">Y</atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">default</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">default</atom>
+      </list>
+      <list type="Control" val="cmd tool.attr prim.cube maxZ ?">
+        <atom type="ShowWhenDisabled">1</atom>
+        <atom type="BooleanStyle">default</atom>
+        <atom type="Enable">1</atom>
+        <atom type="Label">Z</atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">default</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">default</atom>
+      </list>
+    </hash>
+    <hash type="Sheet" key="18156687073:sheet">
+      <atom type="Label">Max 3D Gang</atom>
+      <atom type="Desc"></atom>
+      <atom type="Tooltip"></atom>
+      <atom type="Help"></atom>
+      <atom type="Subtext"></atom>
+      <atom type="ShowLabel">1</atom>
+      <atom type="PopupFace">option</atom>
+      <atom type="Enable">0</atom>
+      <atom type="Alignment">default</atom>
+      <atom type="Style">inlinegang</atom>
+      <atom type="Export">0</atom>
+      <atom type="Filter">ViewType: 3D mode</atom>
+      <atom type="FilterCommand"></atom>
+      <atom type="Layout">properties</atom>
+      <atom type="Justification">left</atom>
+      <atom type="Columns">1</atom>
+      <atom type="IconMode">text</atom>
+      <atom type="IconSize">small</atom>
+      <atom type="IconImage"></atom>
+      <atom type="IconResource"></atom>
+      <atom type="StartCollapsed">0</atom>
+      <atom type="EditorColor">none</atom>
+      <atom type="Proficiency">basic</atom>
+      <atom type="Group"></atom>
+      <list type="Control" val="cmd tool.attr prim.capsule maxX ?">
+        <atom type="ShowWhenDisabled">1</atom>
+        <atom type="BooleanStyle">default</atom>
+        <atom type="Enable">1</atom>
+        <atom type="Label">Max X</atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">default</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">default</atom>
+      </list>
+      <list type="Control" val="cmd tool.attr prim.capsule maxY ?">
+        <atom type="ShowWhenDisabled">1</atom>
+        <atom type="BooleanStyle">default</atom>
+        <atom type="Enable">1</atom>
+        <atom type="Label">Y</atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">default</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">default</atom>
+      </list>
+      <list type="Control" val="cmd tool.attr prim.capsule maxZ ?">
+        <atom type="ShowWhenDisabled">1</atom>
+        <atom type="BooleanStyle">default</atom>
+        <atom type="Enable">1</atom>
+        <atom type="Label">Z</atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">default</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">default</atom>
+      </list>
+    </hash>
+    <hash type="Sheet" key="35727086441:sheet">
+      <atom type="Label">Max 3D Gang</atom>
+      <atom type="Desc"></atom>
+      <atom type="Tooltip"></atom>
+      <atom type="Help"></atom>
+      <atom type="Subtext"></atom>
+      <atom type="ShowLabel">1</atom>
+      <atom type="PopupFace">option</atom>
+      <atom type="Enable">0</atom>
+      <atom type="Alignment">default</atom>
+      <atom type="Style">inlinegang</atom>
+      <atom type="Export">0</atom>
+      <atom type="Filter">ViewType: 3D mode</atom>
+      <atom type="FilterCommand"></atom>
+      <atom type="Layout">properties</atom>
+      <atom type="Justification">left</atom>
+      <atom type="Columns">1</atom>
+      <atom type="IconMode">text</atom>
+      <atom type="IconSize">small</atom>
+      <atom type="IconImage"></atom>
+      <atom type="IconResource"></atom>
+      <atom type="StartCollapsed">0</atom>
+      <atom type="EditorColor">none</atom>
+      <atom type="Proficiency">basic</atom>
+      <atom type="Group"></atom>
+      <list type="Control" val="cmd tool.attr prim.cylinder maxX ?">
+        <atom type="ShowWhenDisabled">1</atom>
+        <atom type="BooleanStyle">default</atom>
+        <atom type="Enable">1</atom>
+        <atom type="Label">Max X</atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">default</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">default</atom>
+      </list>
+      <list type="Control" val="cmd tool.attr prim.cylinder maxY ?">
+        <atom type="ShowWhenDisabled">1</atom>
+        <atom type="BooleanStyle">default</atom>
+        <atom type="Enable">1</atom>
+        <atom type="Label">Y</atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">default</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">default</atom>
+      </list>
+      <list type="Control" val="cmd tool.attr prim.cylinder maxZ ?">
+        <atom type="ShowWhenDisabled">1</atom>
+        <atom type="BooleanStyle">default</atom>
+        <atom type="Enable">1</atom>
+        <atom type="Label">Z</atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">default</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">default</atom>
+      </list>
+    </hash>
+    <hash type="Sheet" key="51037686309:sheet">
+      <atom type="Label">Max 3D Gang</atom>
+      <atom type="Desc"></atom>
+      <atom type="Tooltip"></atom>
+      <atom type="Help"></atom>
+      <atom type="Subtext"></atom>
+      <atom type="ShowLabel">1</atom>
+      <atom type="PopupFace">option</atom>
+      <atom type="Enable">0</atom>
+      <atom type="Alignment">default</atom>
+      <atom type="Style">inlinegang</atom>
+      <atom type="Export">0</atom>
+      <atom type="Filter">ViewType: 3D mode</atom>
+      <atom type="FilterCommand"></atom>
+      <atom type="Layout">properties</atom>
+      <atom type="Justification">left</atom>
+      <atom type="Columns">1</atom>
+      <atom type="IconMode">text</atom>
+      <atom type="IconSize">small</atom>
+      <atom type="IconImage"></atom>
+      <atom type="IconResource"></atom>
+      <atom type="StartCollapsed">0</atom>
+      <atom type="EditorColor">none</atom>
+      <atom type="Proficiency">basic</atom>
+      <atom type="Group"></atom>
+      <list type="Control" val="cmd tool.attr prim.ellipsoid maxX ?">
+        <atom type="ShowWhenDisabled">1</atom>
+        <atom type="BooleanStyle">default</atom>
+        <atom type="Enable">1</atom>
+        <atom type="Label">Max X</atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">default</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">default</atom>
+      </list>
+      <list type="Control" val="cmd tool.attr prim.ellipsoid maxY ?">
+        <atom type="ShowWhenDisabled">1</atom>
+        <atom type="BooleanStyle">default</atom>
+        <atom type="Enable">1</atom>
+        <atom type="Label">Y</atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">default</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">default</atom>
+      </list>
+      <list type="Control" val="cmd tool.attr prim.ellipsoid maxZ ?">
+        <atom type="ShowWhenDisabled">1</atom>
+        <atom type="BooleanStyle">default</atom>
+        <atom type="Enable">1</atom>
+        <atom type="Label">Z</atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">default</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">default</atom>
+      </list>
+    </hash>
+    <hash type="Sheet" key="52626686203:sheet">
+      <atom type="Label">Max 3D Gang</atom>
+      <atom type="Desc"></atom>
+      <atom type="Tooltip"></atom>
+      <atom type="Help"></atom>
+      <atom type="Subtext"></atom>
+      <atom type="ShowLabel">1</atom>
+      <atom type="PopupFace">option</atom>
+      <atom type="Enable">0</atom>
+      <atom type="Alignment">default</atom>
+      <atom type="Style">inlinegang</atom>
+      <atom type="Export">0</atom>
+      <atom type="Filter">ViewType: 3D mode</atom>
+      <atom type="FilterCommand"></atom>
+      <atom type="Layout">properties</atom>
+      <atom type="Justification">left</atom>
+      <atom type="Columns">1</atom>
+      <atom type="IconMode">text</atom>
+      <atom type="IconSize">small</atom>
+      <atom type="IconImage"></atom>
+      <atom type="IconResource"></atom>
+      <atom type="StartCollapsed">0</atom>
+      <atom type="EditorColor">none</atom>
+      <atom type="Proficiency">basic</atom>
+      <atom type="Group"></atom>
+      <list type="Control" val="cmd tool.attr prim.toroid maxX ?">
+        <atom type="ShowWhenDisabled">1</atom>
+        <atom type="BooleanStyle">default</atom>
+        <atom type="Enable">1</atom>
+        <atom type="Label">Max X</atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">default</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">default</atom>
+      </list>
+      <list type="Control" val="cmd tool.attr prim.toroid maxY ?">
+        <atom type="ShowWhenDisabled">1</atom>
+        <atom type="BooleanStyle">default</atom>
+        <atom type="Enable">1</atom>
+        <atom type="Label">Y</atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">default</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">default</atom>
+      </list>
+      <list type="Control" val="cmd tool.attr prim.toroid maxZ ?">
+        <atom type="ShowWhenDisabled">1</atom>
+        <atom type="BooleanStyle">default</atom>
+        <atom type="Enable">1</atom>
+        <atom type="Label">Z</atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">default</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">default</atom>
+      </list>
+    </hash>
+    <hash type="Sheet" key="58156687673:sheet">
+      <atom type="Label">Max 3D Gang</atom>
+      <atom type="Desc"></atom>
+      <atom type="Tooltip"></atom>
+      <atom type="Help"></atom>
+      <atom type="Subtext"></atom>
+      <atom type="ShowLabel">1</atom>
+      <atom type="PopupFace">option</atom>
+      <atom type="Enable">0</atom>
+      <atom type="Alignment">default</atom>
+      <atom type="Style">inlinegang</atom>
+      <atom type="Export">0</atom>
+      <atom type="Filter">ViewType: 3D mode</atom>
+      <atom type="FilterCommand"></atom>
+      <atom type="Layout">properties</atom>
+      <atom type="Justification">left</atom>
+      <atom type="Columns">1</atom>
+      <atom type="IconMode">text</atom>
+      <atom type="IconSize">small</atom>
+      <atom type="IconImage"></atom>
+      <atom type="IconResource"></atom>
+      <atom type="StartCollapsed">0</atom>
+      <atom type="EditorColor">none</atom>
+      <atom type="Proficiency">basic</atom>
+      <atom type="Group"></atom>
+      <list type="Control" val="cmd tool.attr prim.capsule maxX ?">
+        <atom type="ShowWhenDisabled">1</atom>
+        <atom type="BooleanStyle">default</atom>
+        <atom type="Enable">1</atom>
+        <atom type="Label">Max X</atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">default</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">default</atom>
+      </list>
+      <list type="Control" val="cmd tool.attr prim.capsule maxY ?">
+        <atom type="ShowWhenDisabled">1</atom>
+        <atom type="BooleanStyle">default</atom>
+        <atom type="Enable">1</atom>
+        <atom type="Label">Y</atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">default</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">default</atom>
+      </list>
+    </hash>
+    <hash type="Sheet" key="64784690522:sheet">
+      <atom type="Label">Max 3D Gang</atom>
+      <atom type="Desc"></atom>
+      <atom type="Tooltip"></atom>
+      <atom type="Help"></atom>
+      <atom type="Subtext"></atom>
+      <atom type="ShowLabel">1</atom>
+      <atom type="PopupFace">option</atom>
+      <atom type="Enable">0</atom>
+      <atom type="Alignment">default</atom>
+      <atom type="Style">inlinegang</atom>
+      <atom type="Export">0</atom>
+      <atom type="Filter">ViewType: 3D mode</atom>
+      <atom type="FilterCommand"></atom>
+      <atom type="Layout">properties</atom>
+      <atom type="Justification">left</atom>
+      <atom type="Columns">1</atom>
+      <atom type="IconMode">text</atom>
+      <atom type="IconSize">small</atom>
+      <atom type="IconImage"></atom>
+      <atom type="IconResource"></atom>
+      <atom type="StartCollapsed">0</atom>
+      <atom type="EditorColor">none</atom>
+      <atom type="Proficiency">basic</atom>
+      <atom type="Group"></atom>
+      <list type="Control" val="cmd tool.attr prim.sphere maxX ?">
+        <atom type="ShowWhenDisabled">1</atom>
+        <atom type="BooleanStyle">default</atom>
+        <atom type="Enable">1</atom>
+        <atom type="Label">Max X</atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">default</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">default</atom>
+      </list>
+      <list type="Control" val="cmd tool.attr prim.sphere maxY ?">
+        <atom type="ShowWhenDisabled">1</atom>
+        <atom type="BooleanStyle">default</atom>
+        <atom type="Enable">1</atom>
+        <atom type="Label">Y</atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">default</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">default</atom>
+      </list>
+      <list type="Control" val="cmd tool.attr prim.sphere maxZ ?">
+        <atom type="ShowWhenDisabled">1</atom>
+        <atom type="BooleanStyle">default</atom>
+        <atom type="Enable">1</atom>
+        <atom type="Label">Z</atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">default</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">default</atom>
+      </list>
+    </hash>
+    <hash type="Sheet" key="96063682330:sheet">
+      <atom type="Label">Max 3D Gang</atom>
+      <atom type="Desc"></atom>
+      <atom type="Tooltip"></atom>
+      <atom type="Help"></atom>
+      <atom type="Subtext"></atom>
+      <atom type="ShowLabel">1</atom>
+      <atom type="PopupFace">option</atom>
+      <atom type="Enable">0</atom>
+      <atom type="Alignment">default</atom>
+      <atom type="Style">inlinegang</atom>
+      <atom type="Export">0</atom>
+      <atom type="Filter">ViewType: 3D mode</atom>
+      <atom type="FilterCommand"></atom>
+      <atom type="Layout">properties</atom>
+      <atom type="Justification">left</atom>
+      <atom type="Columns">1</atom>
+      <atom type="IconMode">text</atom>
+      <atom type="IconSize">small</atom>
+      <atom type="IconImage"></atom>
+      <atom type="IconResource"></atom>
+      <atom type="StartCollapsed">0</atom>
+      <atom type="EditorColor">none</atom>
+      <atom type="Proficiency">basic</atom>
+      <atom type="Group"></atom>
+      <list type="Control" val="cmd tool.attr prim.cone maxX ?">
+        <atom type="ShowWhenDisabled">1</atom>
+        <atom type="BooleanStyle">default</atom>
+        <atom type="Enable">1</atom>
+        <atom type="Label">Max X</atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">default</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">default</atom>
+      </list>
+      <list type="Control" val="cmd tool.attr prim.cone maxY ?">
+        <atom type="ShowWhenDisabled">1</atom>
+        <atom type="BooleanStyle">default</atom>
+        <atom type="Enable">1</atom>
+        <atom type="Label">Y</atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">default</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">default</atom>
+      </list>
+      <list type="Control" val="cmd tool.attr prim.cone maxZ ?">
+        <atom type="ShowWhenDisabled">1</atom>
+        <atom type="BooleanStyle">default</atom>
+        <atom type="Enable">1</atom>
+        <atom type="Label">Z</atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">default</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">default</atom>
+      </list>
+    </hash>
+    <hash type="Sheet" key="02635686207:sheet">
+      <atom type="Label">Min 3D Gang</atom>
+      <atom type="Desc"></atom>
+      <atom type="Tooltip"></atom>
+      <atom type="Help"></atom>
+      <atom type="Subtext"></atom>
+      <atom type="ShowLabel">1</atom>
+      <atom type="PopupFace">option</atom>
+      <atom type="Enable">0</atom>
+      <atom type="Alignment">default</atom>
+      <atom type="Style">inlinegang</atom>
+      <atom type="Export">0</atom>
+      <atom type="Filter">ViewType: 3D mode</atom>
+      <atom type="FilterCommand"></atom>
+      <atom type="Layout">properties</atom>
+      <atom type="Justification">left</atom>
+      <atom type="Columns">1</atom>
+      <atom type="IconMode">text</atom>
+      <atom type="IconSize">small</atom>
+      <atom type="IconImage"></atom>
+      <atom type="IconResource"></atom>
+      <atom type="StartCollapsed">0</atom>
+      <atom type="EditorColor">none</atom>
+      <atom type="Proficiency">basic</atom>
+      <atom type="Group"></atom>
+      <list type="Control" val="cmd tool.attr prim.toroid minX ?">
+        <atom type="ShowWhenDisabled">1</atom>
+        <atom type="BooleanStyle">default</atom>
+        <atom type="Enable">1</atom>
+        <atom type="Label">Min X</atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">default</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">default</atom>
+      </list>
+      <list type="Control" val="cmd tool.attr prim.toroid minY ?">
+        <atom type="ShowWhenDisabled">1</atom>
+        <atom type="BooleanStyle">default</atom>
+        <atom type="Enable">1</atom>
+        <atom type="Label">Y</atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">default</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">default</atom>
+      </list>
+      <list type="Control" val="cmd tool.attr prim.toroid minZ ?">
+        <atom type="ShowWhenDisabled">1</atom>
+        <atom type="BooleanStyle">default</atom>
+        <atom type="Enable">1</atom>
+        <atom type="Label">Z</atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">default</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">default</atom>
+      </list>
+    </hash>
+    <hash type="Sheet" key="11354086257:sheet">
+      <atom type="Label">Min 3D Gang</atom>
+      <atom type="Desc"></atom>
+      <atom type="Tooltip"></atom>
+      <atom type="Help"></atom>
+      <atom type="Subtext"></atom>
+      <atom type="ShowLabel">1</atom>
+      <atom type="PopupFace">option</atom>
+      <atom type="Enable">0</atom>
+      <atom type="Alignment">default</atom>
+      <atom type="Style">inlinegang</atom>
+      <atom type="Export">0</atom>
+      <atom type="Filter">ViewType: 3D mode</atom>
+      <atom type="FilterCommand"></atom>
+      <atom type="Layout">properties</atom>
+      <atom type="Justification">left</atom>
+      <atom type="Columns">1</atom>
+      <atom type="IconMode">text</atom>
+      <atom type="IconSize">small</atom>
+      <atom type="IconImage"></atom>
+      <atom type="IconResource"></atom>
+      <atom type="StartCollapsed">0</atom>
+      <atom type="EditorColor">none</atom>
+      <atom type="Proficiency">basic</atom>
+      <atom type="Group"></atom>
+      <list type="Control" val="cmd tool.attr prim.cylinder minX ?">
+        <atom type="ShowWhenDisabled">1</atom>
+        <atom type="BooleanStyle">default</atom>
+        <atom type="Enable">1</atom>
+        <atom type="Label">Min X</atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">default</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">default</atom>
+      </list>
+      <list type="Control" val="cmd tool.attr prim.cylinder minY ?">
+        <atom type="ShowWhenDisabled">1</atom>
+        <atom type="BooleanStyle">default</atom>
+        <atom type="Enable">1</atom>
+        <atom type="Label">Y</atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">default</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">default</atom>
+      </list>
+      <list type="Control" val="cmd tool.attr prim.cylinder minZ ?">
+        <atom type="ShowWhenDisabled">1</atom>
+        <atom type="BooleanStyle">default</atom>
+        <atom type="Enable">1</atom>
+        <atom type="Label">Z</atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">default</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">default</atom>
+      </list>
+    </hash>
+    <hash type="Sheet" key="35952690518:sheet">
+      <atom type="Label">Min 3D Gang</atom>
+      <atom type="Desc"></atom>
+      <atom type="Tooltip"></atom>
+      <atom type="Help"></atom>
+      <atom type="Subtext"></atom>
+      <atom type="ShowLabel">1</atom>
+      <atom type="PopupFace">option</atom>
+      <atom type="Enable">0</atom>
+      <atom type="Alignment">default</atom>
+      <atom type="Style">inlinegang</atom>
+      <atom type="Export">0</atom>
+      <atom type="Filter">ViewType: 3D mode</atom>
+      <atom type="FilterCommand"></atom>
+      <atom type="Layout">properties</atom>
+      <atom type="Justification">left</atom>
+      <atom type="Columns">1</atom>
+      <atom type="IconMode">text</atom>
+      <atom type="IconSize">small</atom>
+      <atom type="IconImage"></atom>
+      <atom type="IconResource"></atom>
+      <atom type="StartCollapsed">0</atom>
+      <atom type="EditorColor">none</atom>
+      <atom type="Proficiency">basic</atom>
+      <atom type="Group"></atom>
+      <list type="Control" val="cmd tool.attr prim.sphere minX ?">
+        <atom type="ShowWhenDisabled">1</atom>
+        <atom type="BooleanStyle">default</atom>
+        <atom type="Enable">1</atom>
+        <atom type="Label">Min X</atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">default</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">default</atom>
+      </list>
+      <list type="Control" val="cmd tool.attr prim.sphere minY ?">
+        <atom type="ShowWhenDisabled">1</atom>
+        <atom type="BooleanStyle">default</atom>
+        <atom type="Enable">1</atom>
+        <atom type="Label">Y</atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">default</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">default</atom>
+      </list>
+      <list type="Control" val="cmd tool.attr prim.sphere minZ ?">
+        <atom type="ShowWhenDisabled">1</atom>
+        <atom type="BooleanStyle">default</atom>
+        <atom type="Enable">1</atom>
+        <atom type="Label">Z</atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">default</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">default</atom>
+      </list>
+    </hash>
+    <hash type="Sheet" key="44635686207:sheet">
+      <atom type="Label">Min 3D Gang</atom>
+      <atom type="Desc"></atom>
+      <atom type="Tooltip"></atom>
+      <atom type="Help"></atom>
+      <atom type="Subtext"></atom>
+      <atom type="ShowLabel">1</atom>
+      <atom type="PopupFace">option</atom>
+      <atom type="Enable">0</atom>
+      <atom type="Alignment">default</atom>
+      <atom type="Style">inlinegang</atom>
+      <atom type="Export">0</atom>
+      <atom type="Filter">ViewType: 2D mode</atom>
+      <atom type="FilterCommand"></atom>
+      <atom type="Layout">properties</atom>
+      <atom type="Justification">left</atom>
+      <atom type="Columns">1</atom>
+      <atom type="IconMode">text</atom>
+      <atom type="IconSize">small</atom>
+      <atom type="IconImage"></atom>
+      <atom type="IconResource"></atom>
+      <atom type="StartCollapsed">0</atom>
+      <atom type="EditorColor">none</atom>
+      <atom type="Proficiency">basic</atom>
+      <atom type="Group"></atom>
+      <list type="Control" val="cmd tool.attr prim.toroid minX ?">
+        <atom type="ShowWhenDisabled">1</atom>
+        <atom type="BooleanStyle">default</atom>
+        <atom type="Enable">1</atom>
+        <atom type="Label">Min X</atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">default</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">default</atom>
+      </list>
+      <list type="Control" val="cmd tool.attr prim.toroid minY ?">
+        <atom type="ShowWhenDisabled">1</atom>
+        <atom type="BooleanStyle">default</atom>
+        <atom type="Enable">1</atom>
+        <atom type="Label">Y</atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">default</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">default</atom>
+      </list>
+    </hash>
+    <hash type="Sheet" key="47620687069:sheet">
+      <atom type="Label">Min 3D Gang</atom>
+      <atom type="Desc"></atom>
+      <atom type="Tooltip"></atom>
+      <atom type="Help"></atom>
+      <atom type="Subtext"></atom>
+      <atom type="ShowLabel">1</atom>
+      <atom type="PopupFace">option</atom>
+      <atom type="Enable">0</atom>
+      <atom type="Alignment">default</atom>
+      <atom type="Style">inlinegang</atom>
+      <atom type="Export">0</atom>
+      <atom type="Filter">ViewType: 3D mode</atom>
+      <atom type="FilterCommand"></atom>
+      <atom type="Layout">properties</atom>
+      <atom type="Justification">left</atom>
+      <atom type="Columns">1</atom>
+      <atom type="IconMode">text</atom>
+      <atom type="IconSize">small</atom>
+      <atom type="IconImage"></atom>
+      <atom type="IconResource"></atom>
+      <atom type="StartCollapsed">0</atom>
+      <atom type="EditorColor">none</atom>
+      <atom type="Proficiency">basic</atom>
+      <atom type="Group"></atom>
+      <list type="Control" val="cmd tool.attr prim.capsule minX ?">
+        <atom type="ShowWhenDisabled">1</atom>
+        <atom type="BooleanStyle">default</atom>
+        <atom type="Enable">1</atom>
+        <atom type="Label">Min X</atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">default</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">default</atom>
+      </list>
+      <list type="Control" val="cmd tool.attr prim.capsule minY ?">
+        <atom type="ShowWhenDisabled">1</atom>
+        <atom type="BooleanStyle">default</atom>
+        <atom type="Enable">1</atom>
+        <atom type="Label">Y</atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">default</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">default</atom>
+      </list>
+      <list type="Control" val="cmd tool.attr prim.capsule minZ ?">
+        <atom type="ShowWhenDisabled">1</atom>
+        <atom type="BooleanStyle">default</atom>
+        <atom type="Enable">1</atom>
+        <atom type="Label">Z</atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">default</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">default</atom>
+      </list>
+    </hash>
+    <hash type="Sheet" key="49229682354:sheet">
+      <atom type="Label">Min 3D Gang</atom>
+      <atom type="Desc"></atom>
+      <atom type="Tooltip"></atom>
+      <atom type="Help"></atom>
+      <atom type="Subtext"></atom>
+      <atom type="ShowLabel">1</atom>
+      <atom type="PopupFace">option</atom>
+      <atom type="Enable">0</atom>
+      <atom type="Alignment">default</atom>
+      <atom type="Style">inlinegang</atom>
+      <atom type="Export">0</atom>
+      <atom type="Filter">ViewType: 3D mode</atom>
+      <atom type="FilterCommand"></atom>
+      <atom type="Layout">properties</atom>
+      <atom type="Justification">left</atom>
+      <atom type="Columns">1</atom>
+      <atom type="IconMode">text</atom>
+      <atom type="IconSize">small</atom>
+      <atom type="IconImage"></atom>
+      <atom type="IconResource"></atom>
+      <atom type="StartCollapsed">0</atom>
+      <atom type="EditorColor">none</atom>
+      <atom type="Proficiency">basic</atom>
+      <atom type="Group"></atom>
+      <list type="Control" val="cmd tool.attr prim.cone minX ?">
+        <atom type="ShowWhenDisabled">1</atom>
+        <atom type="BooleanStyle">default</atom>
+        <atom type="Enable">1</atom>
+        <atom type="Label">Min X</atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">default</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">default</atom>
+      </list>
+      <list type="Control" val="cmd tool.attr prim.cone minY ?">
+        <atom type="ShowWhenDisabled">1</atom>
+        <atom type="BooleanStyle">default</atom>
+        <atom type="Enable">1</atom>
+        <atom type="Label">Y</atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">default</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">default</atom>
+      </list>
+      <list type="Control" val="cmd tool.attr prim.cone minZ ?">
+        <atom type="ShowWhenDisabled">1</atom>
+        <atom type="BooleanStyle">default</atom>
+        <atom type="Enable">1</atom>
+        <atom type="Label">Z</atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">default</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">default</atom>
+      </list>
+    </hash>
+    <hash type="Sheet" key="81695690753:sheet">
+      <atom type="Label">Min 3D Gang</atom>
+      <atom type="Desc"></atom>
+      <atom type="Tooltip"></atom>
+      <atom type="Help"></atom>
+      <atom type="Subtext"></atom>
+      <atom type="ShowLabel">1</atom>
+      <atom type="PopupFace">option</atom>
+      <atom type="Enable">0</atom>
+      <atom type="Alignment">default</atom>
+      <atom type="Style">inlinegang</atom>
+      <atom type="Export">0</atom>
+      <atom type="Filter">ViewType: 3D mode</atom>
+      <atom type="FilterCommand"></atom>
+      <atom type="Layout">properties</atom>
+      <atom type="Justification">left</atom>
+      <atom type="Columns">1</atom>
+      <atom type="IconMode">text</atom>
+      <atom type="IconSize">small</atom>
+      <atom type="IconImage"></atom>
+      <atom type="IconResource"></atom>
+      <atom type="StartCollapsed">0</atom>
+      <atom type="EditorColor">none</atom>
+      <atom type="Proficiency">basic</atom>
+      <atom type="Group"></atom>
+      <list type="Control" val="cmd tool.attr prim.cube minX ?">
+        <atom type="ShowWhenDisabled">1</atom>
+        <atom type="BooleanStyle">default</atom>
+        <atom type="Enable">1</atom>
+        <atom type="Label">Min X</atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">default</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">default</atom>
+      </list>
+      <list type="Control" val="cmd tool.attr prim.cube minY ?">
+        <atom type="ShowWhenDisabled">1</atom>
+        <atom type="BooleanStyle">default</atom>
+        <atom type="Enable">1</atom>
+        <atom type="Label">Y</atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">default</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">default</atom>
+      </list>
+      <list type="Control" val="cmd tool.attr prim.cube minZ ?">
+        <atom type="ShowWhenDisabled">1</atom>
+        <atom type="BooleanStyle">default</atom>
+        <atom type="Enable">1</atom>
+        <atom type="Label">Z</atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">default</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">default</atom>
+      </list>
+    </hash>
+    <hash type="Sheet" key="86631686305:sheet">
+      <atom type="Label">Min 3D Gang</atom>
+      <atom type="Desc"></atom>
+      <atom type="Tooltip"></atom>
+      <atom type="Help"></atom>
+      <atom type="Subtext"></atom>
+      <atom type="ShowLabel">1</atom>
+      <atom type="PopupFace">option</atom>
+      <atom type="Enable">0</atom>
+      <atom type="Alignment">default</atom>
+      <atom type="Style">inlinegang</atom>
+      <atom type="Export">0</atom>
+      <atom type="Filter">ViewType: 3D mode</atom>
+      <atom type="FilterCommand"></atom>
+      <atom type="Layout">properties</atom>
+      <atom type="Justification">left</atom>
+      <atom type="Columns">1</atom>
+      <atom type="IconMode">text</atom>
+      <atom type="IconSize">small</atom>
+      <atom type="IconImage"></atom>
+      <atom type="IconResource"></atom>
+      <atom type="StartCollapsed">0</atom>
+      <atom type="EditorColor">none</atom>
+      <atom type="Proficiency">basic</atom>
+      <atom type="Group"></atom>
+      <list type="Control" val="cmd tool.attr prim.ellipsoid minX ?">
+        <atom type="ShowWhenDisabled">1</atom>
+        <atom type="BooleanStyle">default</atom>
+        <atom type="Enable">1</atom>
+        <atom type="Label">Min X</atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">default</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">default</atom>
+      </list>
+      <list type="Control" val="cmd tool.attr prim.ellipsoid minY ?">
+        <atom type="ShowWhenDisabled">1</atom>
+        <atom type="BooleanStyle">default</atom>
+        <atom type="Enable">1</atom>
+        <atom type="Label">Y</atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">default</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">default</atom>
+      </list>
+      <list type="Control" val="cmd tool.attr prim.ellipsoid minZ ?">
+        <atom type="ShowWhenDisabled">1</atom>
+        <atom type="BooleanStyle">default</atom>
+        <atom type="Enable">1</atom>
+        <atom type="Label">Z</atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">default</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">default</atom>
+      </list>
+    </hash>
+    <hash type="Sheet" key="67355340060:sheet">
+      <atom type="Label">Sphere</atom>
+      <atom type="Desc"></atom>
+      <atom type="Tooltip"></atom>
+      <atom type="Help"></atom>
+      <atom type="Subtext"></atom>
+      <atom type="ShowLabel">1</atom>
+      <atom type="PopupFace">option</atom>
+      <atom type="Enable">1</atom>
+      <atom type="Alignment">default</atom>
+      <atom type="Style">default</atom>
+      <atom type="Export">0</atom>
+      <atom type="Filter">42898550066:filterPreset</atom>
+      <atom type="FilterCommand"></atom>
+      <atom type="Layout">properties</atom>
+      <atom type="Justification">left</atom>
+      <atom type="Columns">1</atom>
+      <atom type="IconMode">text</atom>
+      <atom type="IconSize">small</atom>
+      <atom type="IconImage"></atom>
+      <atom type="IconResource"></atom>
+      <atom type="StartCollapsed">0</atom>
+      <atom type="EditorColor">none</atom>
+      <atom type="Proficiency">basic</atom>
+      <atom type="Group">toolprops/primitives</atom>
+      <list type="Control" val="cmd tool.apply">
+        <atom type="ShowWhenDisabled">1</atom>
+        <atom type="BooleanStyle">default</atom>
+        <atom type="Enable">1</atom>
+        <atom type="Label">Apply</atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">default</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">default</atom>
+      </list>
+      <list type="Control" val="sub 08428950341:sheet">
+        <atom type="Enable">1</atom>
+        <atom type="Label">Position 3D Gang</atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">inlinegang</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">296008592</atom>
+      </list>
+      <list type="Control" val="sub 18428950340:sheet">
+        <atom type="Enable">1</atom>
+        <atom type="Label">Position 2D Gang</atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">inlinegang</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">296009488</atom>
+      </list>
+      <list type="Control" val="sub 46151730044:sheet">
+        <atom type="Enable">1</atom>
+        <atom type="Label">Radius 3D Gang</atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">inlinegang</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">296008656</atom>
+      </list>
+      <list type="Control" val="sub 56151730043:sheet">
+        <atom type="Enable">1</atom>
+        <atom type="Label">Radius 2D Gang</atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">inlinegang</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">296008976</atom>
+      </list>
+      <list type="Control" val="div ">
+        <atom type="ShowWhenDisabled">1</atom>
+        <atom type="BooleanStyle">default</atom>
+        <atom type="Enable">1</atom>
+        <atom type="Label"></atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">wide</atom>
+        <atom type="Style">default</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">default</atom>
+        <atom type="Hash">{control} UID (Fri May 07 06:16:28 2004) 338766152</atom>
+      </list>
+      <list type="Control" val="cmd tool.attr prim.sphere sides ?">
+        <atom type="ShowWhenDisabled">1</atom>
+        <atom type="BooleanStyle">default</atom>
+        <atom type="Enable">1</atom>
+        <atom type="Label"></atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">default</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">default</atom>
+      </list>
+      <list type="Control" val="cmd tool.attr prim.sphere segments ?">
+        <atom type="ShowWhenDisabled">1</atom>
+        <atom type="BooleanStyle">default</atom>
+        <atom type="Enable">1</atom>
+        <atom type="Label"></atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">default</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">default</atom>
+      </list>
+      <list type="Control" val="div ">
+        <atom type="ShowWhenDisabled">1</atom>
+        <atom type="BooleanStyle">default</atom>
+        <atom type="Enable">1</atom>
+        <atom type="Label"></atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">wide</atom>
+        <atom type="Style">default</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">default</atom>
+        <atom type="Hash">{control} UID (Fri May 07 06:16:36 2004) 353742011</atom>
+      </list>
+      <list type="Control" val="cmd tool.attr prim.sphere method ?">
+        <atom type="ShowWhenDisabled">1</atom>
+        <atom type="BooleanStyle">default</atom>
+        <atom type="Enable">1</atom>
+        <atom type="Label"></atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">default</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">default</atom>
+      </list>
+      <list type="Control" val="cmd tool.attr prim.sphere order ?">
+        <atom type="ShowWhenDisabled">1</atom>
+        <atom type="BooleanStyle">default</atom>
+        <atom type="Enable">1</atom>
+        <atom type="Label"></atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">default</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">default</atom>
+      </list>
+      <list type="Control" val="cmd tool.attr prim.sphere polType ?">
+        <atom type="ShowWhenDisabled">1</atom>
+        <atom type="BooleanStyle">default</atom>
+        <atom type="Enable">1</atom>
+        <atom type="Label"></atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">default</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">default</atom>
+      </list>
+      <list type="Control" val="div ">
+        <atom type="ShowWhenDisabled">1</atom>
+        <atom type="BooleanStyle">default</atom>
+        <atom type="Enable">1</atom>
+        <atom type="Label"></atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">wide</atom>
+        <atom type="Style">default</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">default</atom>
+        <atom type="Hash">{control} UID (Fri May 07 06:16:51 2004) 387208065</atom>
+      </list>
+      <list type="Control" val="cmd tool.attr prim.sphere axis ?">
+        <atom type="ShowWhenDisabled">1</atom>
+        <atom type="BooleanStyle">default</atom>
+        <atom type="Enable">1</atom>
+        <atom type="Label"></atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">default</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">default</atom>
+      </list>
+      <list type="Control" val="cmd tool.attr prim.sphere uvs ?">
+        <atom type="ShowWhenDisabled">1</atom>
+        <atom type="BooleanStyle">default</atom>
+        <atom type="Enable">1</atom>
+        <atom type="Label"></atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">default</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">default</atom>
+      </list>
+      <list type="Control" val="div ">
+        <atom type="ShowWhenDisabled">1</atom>
+        <atom type="BooleanStyle">default</atom>
+        <atom type="Enable">1</atom>
+        <atom type="Label"></atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">wide</atom>
+        <atom type="Style">default</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">default</atom>
+        <atom type="Hash">{control} UID (Fri May 07 07:11:58 2004) 357899846</atom>
+      </list>
+      <list type="Control" val="cmd tool.attr prim.sphere handleMode ?">
+        <atom type="ShowWhenDisabled">1</atom>
+        <atom type="BooleanStyle">default</atom>
+        <atom type="Enable">1</atom>
+        <atom type="Label">Handle Mode</atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">default</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">default</atom>
+      </list>
+      <list type="Control" val="cmd tool.attr prim.sphere showCorner ?">
+        <atom type="ShowWhenDisabled">1</atom>
+        <atom type="BooleanStyle">default</atom>
+        <atom type="Enable">1</atom>
+        <atom type="Label">Show Corner</atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">default</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">default</atom>
+      </list>
+      <list type="Control" val="div ">
+        <atom type="ShowWhenDisabled">1</atom>
+        <atom type="BooleanStyle">default</atom>
+        <atom type="Enable">1</atom>
+        <atom type="Label"></atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">wide</atom>
+        <atom type="Style">default</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">default</atom>
+        <atom type="Hash">21081077426:control</atom>
+      </list>
+      <list type="Control" val="sub 35952690518:sheet">
+        <atom type="Enable">0</atom>
+        <atom type="Label">Min 3D Gang</atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">inlinegang</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">296009584</atom>
+      </list>
+      <list type="Control" val="sub 45952690517:sheet">
+        <atom type="Enable">1</atom>
+        <atom type="Label">Min 2D Gang</atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">inlinegang</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">296012112</atom>
+      </list>
+      <list type="Control" val="sub 64784690522:sheet">
+        <atom type="Enable">0</atom>
+        <atom type="Label">Max 3D Gang</atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">inlinegang</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">296008176</atom>
+      </list>
+      <list type="Control" val="sub 74784690521:sheet">
+        <atom type="Enable">1</atom>
+        <atom type="Label">Max 2D Gang</atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">inlinegang</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">296008400</atom>
+      </list>
+      <list type="Control" val="div ">
+        <atom type="ShowWhenDisabled">1</atom>
+        <atom type="BooleanStyle">default</atom>
+        <atom type="Enable">1</atom>
+        <atom type="Label"></atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">wide</atom>
+        <atom type="Style">default</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">default</atom>
+        <atom type="Hash">{control} UID (Fri May 07 07:11:58 2004) 357899846</atom>
+      </list>
+      <hash type="InCategory" key="toolprops:main#head">
+        <atom type="Ordinal">150.50</atom>
+      </hash>
+    </hash>
+    <hash type="Sheet" key="44549560204:sheet">
+      <atom type="Label">Torus</atom>
+      <atom type="Desc"></atom>
+      <atom type="Tooltip"></atom>
+      <atom type="Help"></atom>
+      <atom type="Subtext"></atom>
+      <atom type="ShowLabel">1</atom>
+      <atom type="PopupFace">option</atom>
+      <atom type="Enable">1</atom>
+      <atom type="Alignment">default</atom>
+      <atom type="Style">default</atom>
+      <atom type="Export">0</atom>
+      <atom type="Filter">07791130091:filterPreset</atom>
+      <atom type="FilterCommand"></atom>
+      <atom type="Layout">properties</atom>
+      <atom type="Justification">left</atom>
+      <atom type="Columns">1</atom>
+      <atom type="IconMode">text</atom>
+      <atom type="IconSize">small</atom>
+      <atom type="IconImage"></atom>
+      <atom type="IconResource"></atom>
+      <atom type="StartCollapsed">0</atom>
+      <atom type="EditorColor">none</atom>
+      <atom type="Proficiency">basic</atom>
+      <atom type="Group">toolprops/primitives</atom>
+      <list type="Control" val="cmd tool.apply">
+        <atom type="ShowWhenDisabled">1</atom>
+        <atom type="BooleanStyle">default</atom>
+        <atom type="Enable">1</atom>
+        <atom type="Label">Apply</atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">default</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">default</atom>
+      </list>
+      <list type="Control" val="sub 84301750089:sheet">
+        <atom type="Enable">1</atom>
+        <atom type="Label">Position 3D Gang</atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">inlinegang</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">296837168</atom>
+      </list>
+      <list type="Control" val="sub 54301750089:sheet">
+        <atom type="Enable">1</atom>
+        <atom type="Label">Position 2D Gang</atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">inlinegang</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">296838864</atom>
+      </list>
+      <list type="Control" val="div ">
+        <atom type="ShowWhenDisabled">1</atom>
+        <atom type="BooleanStyle">default</atom>
+        <atom type="Enable">1</atom>
+        <atom type="Label"></atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">wide</atom>
+        <atom type="Style">default</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">default</atom>
+        <atom type="Hash">{control} UID (Dri Day C7 F6:utile 2104) 535787057</atom>
+      </list>
+      <list type="Control" val="cmd tool.attr prim.toroid ringRadius ?">
+        <atom type="ShowWhenDisabled">1</atom>
+        <atom type="BooleanStyle">default</atom>
+        <atom type="Enable">1</atom>
+        <atom type="Label">Ring Radius</atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">default</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">default</atom>
+      </list>
+      <list type="Control" val="sub 56194719107:sheet">
+        <atom type="Enable">1</atom>
+        <atom type="Label">Section Gang</atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">inlinegang</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">296838064</atom>
+      </list>
+      <list type="Control" val="div ">
+        <atom type="ShowWhenDisabled">1</atom>
+        <atom type="BooleanStyle">default</atom>
+        <atom type="Enable">1</atom>
+        <atom type="Label"></atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">wide</atom>
+        <atom type="Style">default</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">default</atom>
+        <atom type="Hash">{control} UID (Fri May 07 06:57:14 2004) 379809057</atom>
+      </list>
+      <list type="Control" val="cmd tool.attr prim.toroid sides ?">
+        <atom type="ShowWhenDisabled">1</atom>
+        <atom type="BooleanStyle">default</atom>
+        <atom type="Enable">1</atom>
+        <atom type="Label"></atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">default</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">default</atom>
+      </list>
+      <list type="Control" val="cmd tool.attr prim.toroid segments ?">
+        <atom type="ShowWhenDisabled">1</atom>
+        <atom type="BooleanStyle">default</atom>
+        <atom type="Enable">1</atom>
+        <atom type="Label"></atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">default</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">default</atom>
+      </list>
+      <list type="Control" val="cmd tool.attr prim.toroid hole ?">
+        <atom type="ShowWhenDisabled">1</atom>
+        <atom type="BooleanStyle">default</atom>
+        <atom type="Enable">1</atom>
+        <atom type="Label"></atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">default</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">default</atom>
+      </list>
+      <list type="Control" val="cmd tool.attr prim.toroid polType ?">
+        <atom type="ShowWhenDisabled">1</atom>
+        <atom type="BooleanStyle">default</atom>
+        <atom type="Enable">1</atom>
+        <atom type="Label"></atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">default</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">default</atom>
+      </list>
+      <list type="Control" val="div ">
+        <atom type="ShowWhenDisabled">1</atom>
+        <atom type="BooleanStyle">default</atom>
+        <atom type="Enable">1</atom>
+        <atom type="Label"></atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">wide</atom>
+        <atom type="Style">default</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">default</atom>
+        <atom type="Hash">{control} UID (Fri May 07 06:57:16 2004) 382863081</atom>
+      </list>
+      <list type="Control" val="sub 05078120364:sheet">
+        <atom type="Enable">1</atom>
+        <atom type="Label">Bulge Group</atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">inlinegang</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">296838288</atom>
+      </list>
+      <list type="Control" val="div ">
+        <atom type="ShowWhenDisabled">1</atom>
+        <atom type="BooleanStyle">default</atom>
+        <atom type="Enable">1</atom>
+        <atom type="Label"></atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">wide</atom>
+        <atom type="Style">default</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">default</atom>
+        <atom type="Hash">{control} UID (Fri May 07 06:58:32 2004) 274924698</atom>
+      </list>
+      <list type="Control" val="cmd tool.attr prim.toroid axis ?">
+        <atom type="ShowWhenDisabled">1</atom>
+        <atom type="BooleanStyle">default</atom>
+        <atom type="Enable">1</atom>
+        <atom type="Label"></atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">default</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">default</atom>
+      </list>
+      <list type="Control" val="cmd tool.attr prim.toroid uvs ?">
+        <atom type="ShowWhenDisabled">1</atom>
+        <atom type="BooleanStyle">default</atom>
+        <atom type="Enable">1</atom>
+        <atom type="Label"></atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">default</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">default</atom>
+      </list>
+      <list type="Control" val="div ">
+        <atom type="ShowWhenDisabled">1</atom>
+        <atom type="BooleanStyle">default</atom>
+        <atom type="Enable">1</atom>
+        <atom type="Label"></atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">wide</atom>
+        <atom type="Style">default</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">default</atom>
+        <atom type="Hash">{control} UID (Fri May 07 07:11:58 2004) 357899846</atom>
+      </list>
+      <list type="Control" val="cmd tool.attr prim.toroid handleMode ?">
+        <atom type="ShowWhenDisabled">1</atom>
+        <atom type="BooleanStyle">default</atom>
+        <atom type="Enable">1</atom>
+        <atom type="Label">Handle Mode</atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">default</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">default</atom>
+      </list>
+      <list type="Control" val="cmd tool.attr prim.toroid showCorner ?">
+        <atom type="ShowWhenDisabled">1</atom>
+        <atom type="BooleanStyle">default</atom>
+        <atom type="Enable">1</atom>
+        <atom type="Label">Show Corner</atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">default</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">default</atom>
+      </list>
+      <list type="Control" val="div ">
+        <atom type="ShowWhenDisabled">1</atom>
+        <atom type="BooleanStyle">default</atom>
+        <atom type="Enable">1</atom>
+        <atom type="Label"></atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">wide</atom>
+        <atom type="Style">default</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">default</atom>
+        <atom type="Hash">26081077426:control</atom>
+      </list>
+      <list type="Control" val="sub 39270010240:sheet">
+        <atom type="Enable">1</atom>
+        <atom type="Label">Size 3D Gang</atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">inlinegang</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">296837648</atom>
+      </list>
+      <list type="Control" val="sub 39273310240:sheet">
+        <atom type="Enable">1</atom>
+        <atom type="Label">Size 2D Gang</atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">inlinegang</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">296838480</atom>
+      </list>
+      <list type="Control" val="sub 52626686203:sheet">
+        <atom type="Enable">0</atom>
+        <atom type="Label">Max 3D Gang</atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">inlinegang</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">296838928</atom>
+      </list>
+      <list type="Control" val="sub 33626686203:sheet">
+        <atom type="Enable">1</atom>
+        <atom type="Label">Max 2D Gang</atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">inlinegang</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">296839152</atom>
+      </list>
+      <list type="Control" val="sub 02635686207:sheet">
+        <atom type="Enable">0</atom>
+        <atom type="Label">Min 3D Gang</atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">inlinegang</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">296837616</atom>
+      </list>
+      <list type="Control" val="sub 44635686207:sheet">
+        <atom type="Enable">0</atom>
+        <atom type="Label">Min 3D Gang</atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">default</atom>
+        <atom type="Style">inlinegang</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">296839984</atom>
+      </list>
+      <list type="Control" val="div ">
+        <atom type="ShowWhenDisabled">1</atom>
+        <atom type="BooleanStyle">default</atom>
+        <atom type="Enable">1</atom>
+        <atom type="Label"></atom>
+        <atom type="Help"></atom>
+        <atom type="Tooltip"></atom>
+        <atom type="Desc"></atom>
+        <atom type="Subtext"></atom>
+        <atom type="ShowLabel">1</atom>
+        <atom type="PopupFace">option</atom>
+        <atom type="Alignment">wide</atom>
+        <atom type="Style">default</atom>
+        <atom type="IconImage"></atom>
+        <atom type="IconResource"></atom>
+        <atom type="StartCollapsed">0</atom>
+        <atom type="EditorColor">none</atom>
+        <atom type="Proficiency">basic</atom>
+        <atom type="ProficiencyOverride">default</atom>
+        <atom type="Hash">86543686211:control</atom>
+      </list>
+      <hash type="InCategory" key="toolprops:main#head">
+        <atom type="Ordinal">150.95</atom>
+      </hash>
+    </hash>
+  </atom>
+</configuration>

--- a/Configs/Action Center Pie.CFG
+++ b/Configs/Action Center Pie.CFG
@@ -1,0 +1,80 @@
+<?xml version="1.0"?>
+<configuration>
+  <atom type="Attributes">
+    <hash type="Sheet" key="18184886527:sheet">
+      <atom type="Label">Action Centers</atom>
+      <atom type="Desc">Hotkey = alt-a (registered in GooseBig's InputRemapping.CFG)</atom>
+      <atom type="Style">pie</atom>
+      <atom type="EditorColor">786432</atom>
+      <atom type="Group">piemenus</atom>
+      <list type="Control" val="cmd tool.clearTask axis center">
+        <atom type="Label">Clear Action Center</atom>
+      </list>
+      <list type="Control" val="cmd tool.set actr.select on">
+        <atom type="Label">Selection</atom>
+      </list>
+      <list type="Control" val="cmd tool.set actr.selectauto on">
+        <atom type="Label">Select Auto Axis</atom>
+      </list>
+      <list type="Control" val="cmd tool.set actr.element on">
+        <atom type="Label">Element</atom>
+      </list>
+      <list type="Control" val="sub 37957362720:sheet">
+        <atom type="Label">Axis...</atom>
+        <atom type="Style">pie</atom>
+        <atom type="Hash">37957362720:sheet</atom>
+      </list>
+      <list type="Control" val="cmd tool.set actr.origin on">
+        <atom type="Label">Origin</atom>
+      </list>
+      <list type="Control" val="cmd tool.set actr.local on">
+        <atom type="Label">Local</atom>
+      </list>
+      <list type="Control" val="cmd tool.set actr.auto on 0">
+        <atom type="Label">Automatic</atom>
+      </list>
+      <list type="Control" val="cmd tool.set actr.pivot on">
+        <atom type="Label">Pivot</atom>
+      </list>
+      <list type="Control" val="cmd tool.set actr.screen on">
+        <atom type="Label">Screen</atom>
+      </list>
+    </hash>
+    <hash type="Sheet" key="37957362720:sheet">
+      <atom type="Label">Axis...</atom>
+      <atom type="Style">pie</atom>
+      <list type="Control" val="cmd tool.set axis.pivot on">
+        <atom type="Label">Pivot</atom>
+        <atom type="Tooltip">@@3007</atom>
+      </list>
+      <list type="Control" val="cmd tool.set axis.select on">
+        <atom type="Label">Selection</atom>
+        <atom type="Tooltip">@@3001</atom>
+      </list>
+      <list type="Control" val="cmd tool.set axis.view on">
+        <atom type="Label">Screen</atom>
+        <atom type="Tooltip">@@3003</atom>
+      </list>
+      <list type="Control" val="cmd tool.set axis.element on">
+        <atom type="Label">Element</atom>
+        <atom type="Tooltip">@@3002</atom>
+      </list>
+      <list type="Control" val="cmd tool.set axis.parent on">
+        <atom type="Label">Parent</atom>
+        <atom type="Tooltip">@@3005</atom>
+      </list>
+      <list type="Control" val="cmd tool.set axis.origin on">
+        <atom type="Label">Origin</atom>
+        <atom type="Tooltip">@@3004</atom>
+      </list>
+      <list type="Control" val="cmd tool.set axis.local on">
+        <atom type="Label">Local</atom>
+        <atom type="Tooltip">@@3006</atom>
+      </list>
+      <list type="Control" val="cmd tool.set axis.auto on">
+        <atom type="Label">Auto</atom>
+        <atom type="Tooltip">@@3000</atom>
+      </list>
+    </hash>
+  </atom>
+</configuration>

--- a/Configs/Background Mesh Display Pie_fixed.CFG
+++ b/Configs/Background Mesh Display Pie_fixed.CFG
@@ -1,0 +1,30 @@
+<?xml version="1.0"?>
+<configuration>
+  <atom type="Attributes">
+    <hash type="Sheet" key="BkgndLyrDisplayPieMenu:sheet">
+      <atom type="Label">BkgndMeshDisplay</atom>
+      <atom type="Style">pie</atom>
+      <atom type="Group">piemenus</atom>
+      <list type="Control" val="cmd view3d.inactiveInvisible ?+">
+        <atom type="Label">Invisible</atom>
+      </list>
+      <list type="Control" val="cmd view3d.shadingStyle wire inactive">
+        <atom type="Label">Wireframe</atom>
+      </list>
+      <list type="Control" val="cmd view3d.shadingStyle shade inactive">
+        <atom type="Label">Flat Shaded</atom>
+      </list>
+      <list type="Control" val="cmd ">
+      </list>
+      <list type="Control" val="cmd view3d.showweights ?+">
+        <atom type="Label">Show Weightmaps</atom>
+      </list>
+      <list type="Control" val="cmd ">
+      </list>
+      <list type="Control" val="cmd view3d.sameAsActive ?+">
+        <atom type="Label">Same as Active</atom>
+        <atom type="Desc">view3d.sameAsActive ?+</atom>
+      </list>
+    </hash>
+  </atom>
+</configuration>

--- a/Configs/ETEREA Primitives Enhanced.CFG
+++ b/Configs/ETEREA Primitives Enhanced.CFG
@@ -1,0 +1,550 @@
+<?xml version="1.0"?>
+<configuration>
+  <atom type="Attributes">
+    <hash type="Sheet" key="79312484437:sheet">
+      <atom type="Label">ETEREA Primitives</atom>
+      <atom type="Export">1</atom>
+      <atom type="IconMode">icon</atom>
+      <atom type="IconSize">large</atom>
+      <atom type="Group">ETEREA/Primitives</atom>
+      <list type="Control" val="sub 70372507537:sheet">
+        <atom type="Label">Cube, pen and splines</atom>
+        <atom type="Hash">70372507537:sheet</atom>
+      </list>
+      <list type="Control" val="sub 73921507421:sheet">
+        <atom type="Label">Cylinder Presets (Facetted)</atom>
+        <atom type="Hash">73921507421:sheet</atom>
+      </list>
+      <list type="Control" val="sub 86358507484:sheet">
+        <atom type="Label">Sphere Presets (Subdivided)</atom>
+        <atom type="Hash">86358507484:sheet</atom>
+      </list>
+      <list type="Control" val="sub 96872507600:sheet">
+        <atom type="Label">Units and others</atom>
+        <atom type="Hash">96872507600:sheet</atom>
+      </list>
+    </hash>
+    <hash type="Sheet" key="70372507537:sheet">
+      <atom type="Label">Cube, pen and splines</atom>
+      <atom type="Layout">htoolbar</atom>
+      <atom type="Justification">justified</atom>
+      <atom type="IconMode">icon</atom>
+      <atom type="IconSize">large</atom>
+      <list type="Control" val="cmd tool.set eterea.prim.cube on">
+        <atom type="Label">Square</atom>
+        <atom type="Tooltip">Square</atom>
+      <atom type="IconResource">etr_prm_cube</atom>
+      </list>
+      <list type="Control" val="cmd tool.set eterea.prim.pen.polyfacet on">
+        <atom type="Label">Polygon Facet</atom>
+        <atom type="Tooltip">Polygon Facet</atom>
+      <atom type="IconResource">etr_prm_pen_polyfacet</atom>
+      </list>
+      <list type="Control" val="cmd tool.set eterea.prim.pen.polysubd on">
+        <atom type="Label">Polygon Subd</atom>
+        <atom type="Tooltip">Polygon Subd</atom>
+      <atom type="IconResource">etr_prm_pen_polysubd</atom>
+      </list>
+      <list type="Control" val="cmd tool.set eterea.prim.pen.lines on">
+        <atom type="Label">Lines</atom>
+        <atom type="Tooltip">Lines</atom>
+      <atom type="IconResource">etr_prm_pen_lines</atom>
+      </list>
+      <list type="Control" val="cmd tool.set eterea.prim.pen.wallfacets on">
+        <atom type="Label">Wall Facets</atom>
+        <atom type="Tooltip">Wall Facets</atom>
+      <atom type="IconResource">etr_prm_pen_wallfacets</atom>
+      </list>
+      <list type="Control" val="cmd tool.set eterea.prim.pen.wallsubd on">
+        <atom type="Label">Wall Subd</atom>
+        <atom type="Tooltip">Wall Subd</atom>
+      <atom type="IconResource">etr_prm_pen_wallsubd</atom>
+      </list>
+      <list type="Control" val="cmd tool.set eterea.prim.pen.quads on">
+        <atom type="Label">Quads</atom>
+        <atom type="Tooltip">Quads</atom>
+      <atom type="IconResource">etr_prm_pen_quads</atom>
+      </list>
+      <list type="Control" val="sub 48528939950:sheet">
+        <atom type="Label">Curve_</atom>
+        <atom type="Style">toolchoice</atom>
+        <atom type="Hash">48528939950:sheet</atom>
+      </list>
+      <list type="Control" val="cmd tool.set &quot;prim.text&quot; &quot;on&quot;">
+        <atom type="Label">Text</atom>
+        <atom type="Tooltip">@@3003</atom>
+      </list>
+    </hash>
+    <hash type="Sheet" key="48528939950:sheet">
+      <atom type="Label">Curve_</atom>
+      <atom type="Style">toolchoice</atom>
+      <atom type="Layout">htoolbar</atom>
+      <atom type="Justification">left</atom>
+      <atom type="IconMode">icon</atom>
+      <atom type="IconSize">large</atom>
+      <list type="Control" val="cmd tool.set prim.curve on">
+        <atom type="Label">Curve</atom>
+        <atom type="Tooltip">Curve</atom>
+      </list>
+      <list type="Control" val="cmd tool.set prim.bezier on">
+        <atom type="Label">Bezier</atom>
+        <atom type="Tooltip">Bezier</atom>
+      </list>
+    </hash>
+    <hash type="Sheet" key="73921507421:sheet">
+      <atom type="Label">Cylinder Presets (Facetted)</atom>
+      <atom type="Layout">htoolbar</atom>
+      <atom type="Justification">justified</atom>
+      <atom type="IconMode">icon</atom>
+      <atom type="IconSize">large</atom>
+      <list type="Control" val="cmd tool.set eterea.prim.cylinder.3 on">
+        <atom type="Label">3 sides facetted polygon</atom>
+        <atom type="Tooltip">3 sides facetted polygon</atom>
+      <atom type="IconResource">etr_prm_cylinder_3</atom>
+      </list>
+      <list type="Control" val="cmd tool.set eterea.prim.cylinder.4 on">
+        <atom type="Label">4 sides facetted polygon</atom>
+        <atom type="Tooltip">4 sides facetted polygon</atom>
+      <atom type="IconResource">etr_prm_cylinder_4</atom>
+      </list>
+      <list type="Control" val="cmd tool.set eterea.prim.cylinder.5 on">
+        <atom type="Label">5 sides facetted polygon</atom>
+        <atom type="Tooltip">5 sides facetted polygon</atom>
+      <atom type="IconResource">etr_prm_cylinder_5</atom>
+      </list>
+      <list type="Control" val="cmd tool.set eterea.prim.cylinder.6 on">
+        <atom type="Label">6 sides facetted polygon</atom>
+        <atom type="Tooltip">6 sides facetted polygon</atom>
+      <atom type="IconResource">etr_prm_cylinder_6</atom>
+      </list>
+      <list type="Control" val="cmd tool.set eterea.prim.cylinder.8 on">
+        <atom type="Label">8 sides facetted polygon</atom>
+        <atom type="Tooltip">8 sides facetted polygon</atom>
+      <atom type="IconResource">etr_prm_cylinder_8</atom>
+      </list>
+      <list type="Control" val="cmd tool.set eterea.prim.cylinder.12 on">
+        <atom type="Label">12 sides facetted polygon</atom>
+        <atom type="Tooltip">12 sides facetted polygon</atom>
+      <atom type="IconResource">etr_prm_cylinder_12</atom>
+      </list>
+      <list type="Control" val="cmd tool.set eterea.prim.cylinder.16 on">
+        <atom type="Label">16 sides facetted polygon</atom>
+        <atom type="Tooltip">16 sides facetted polygon</atom>
+      <atom type="IconResource">etr_prm_cylinder_16</atom>
+      </list>
+      <list type="Control" val="cmd tool.set eterea.prim.cylinder.24 on">
+        <atom type="Label">24 sides facetted polygon</atom>
+        <atom type="Tooltip">24 sides facetted polygon</atom>
+      <atom type="IconResource">etr_prm_cylinder_24</atom>
+      </list>
+      <list type="Control" val="cmd tool.set eterea.prim.cylinder.36 on">
+        <atom type="Label">36 sides facetted polygon</atom>
+        <atom type="Tooltip">36 sides facetted polygon</atom>
+      <atom type="IconResource">etr_prm_cylinder_36</atom>
+      </list>
+    </hash>
+    <hash type="Sheet" key="86358507484:sheet">
+      <atom type="Label">Sphere Presets (Subdivided)</atom>
+      <atom type="Layout">htoolbar</atom>
+      <atom type="Justification">justified</atom>
+      <atom type="IconMode">icon</atom>
+      <atom type="IconSize">large</atom>
+      <list type="Control" val="cmd tool.set eterea.prim.sphere.3 on">
+        <list type="AltCmd" val="tool.set eterea.prim.sphere.3 on">
+          <atom type="AltCmdLabel">3 sides subdivided polygon</atom>
+          <atom type="AltCmdQualifiers">ctrl</atom>
+        </list>
+        <atom type="Label">3 sides subdivided polygon</atom>
+        <atom type="Tooltip">3 sides subdivided polygon</atom>
+      <atom type="IconResource">etr_prm_sphere_3</atom>
+      </list>
+      <list type="Control" val="cmd tool.set eterea.prim.sphere.4 on">
+        <atom type="Label">4 sides subdivided polygon</atom>
+        <atom type="Tooltip">4 sides subdivided polygon</atom>
+      <atom type="IconResource">etr_prm_sphere_4</atom>
+      </list>
+      <list type="Control" val="cmd tool.set eterea.prim.sphere.5 on">
+        <atom type="Label">5 sides subdivided polygon</atom>
+        <atom type="Tooltip">5 sides subdivided polygon</atom>
+      <atom type="IconResource">etr_prm_sphere_5</atom>
+      </list>
+      <list type="Control" val="cmd tool.set eterea.prim.sphere.6 on">
+        <atom type="Label">6 sides subdivided polygon</atom>
+        <atom type="Tooltip">6 sides subdivided polygon</atom>
+      <atom type="IconResource">etr_prm_sphere_6</atom>
+      </list>
+      <list type="Control" val="cmd tool.set eterea.prim.sphere.8 on">
+        <atom type="Label">8 sides subdivided polygon</atom>
+        <atom type="Tooltip">8 sides subdivided polygon</atom>
+      <atom type="IconResource">etr_prm_sphere_8</atom>
+      </list>
+      <list type="Control" val="cmd tool.set eterea.prim.sphere.12 on">
+        <atom type="Label">12 sides subdivided polygon</atom>
+        <atom type="Tooltip">12 sides subdivided polygon</atom>
+      <atom type="IconResource">etr_prm_sphere_12</atom>
+      </list>
+      <list type="Control" val="cmd tool.set eterea.prim.sphere.16 on">
+        <atom type="Label">16 sides subdivided polygon</atom>
+        <atom type="Tooltip">16 sides subdivided polygon</atom>
+      <atom type="IconResource">etr_prm_sphere_16</atom>
+      </list>
+      <list type="Control" val="cmd tool.set eterea.prim.sphere.24 on">
+        <atom type="Label">24 sides subdivided polygon</atom>
+        <atom type="Tooltip">24 sides subdivided polygon</atom>
+      <atom type="IconResource">etr_prm_sphere_24</atom>
+      </list>
+      <list type="Control" val="cmd tool.set eterea.prim.sphere.36 on">
+        <atom type="Label">36 sides subdivided polygon</atom>
+        <atom type="Tooltip">36 sides subdivided polygon</atom>
+      <atom type="IconResource">etr_prm_sphere_36</atom>
+      </list>
+    </hash>
+    <hash type="Sheet" key="96872507600:sheet">
+      <atom type="Label">Units and others</atom>
+      <atom type="Layout">htoolbar</atom>
+      <atom type="Justification">justified</atom>
+      <atom type="IconMode">icon</atom>
+      <atom type="IconSize">large</atom>
+      <list type="Control" val="cmd tool.set &quot;prim.cube&quot; &quot;on&quot;">
+        <list type="AltCmd" val="script.run &quot;macro.scriptservice:32235710027:macro&quot;">
+          <atom type="AltCmdLabel">Unit Cube</atom>
+          <atom type="AltCmdQualifiers">ctrl</atom>
+        </list>
+        <list type="AltCmd" val="script.run &quot;macro.scriptservice:32235733333:macro&quot;">
+          <atom type="AltCmdLabel">Cube Item</atom>
+          <atom type="AltCmdQualifiers">shift</atom>
+        </list>
+        <atom type="Label">Cube</atom>
+        <atom type="Tooltip">@@3000</atom>
+      </list>
+      <list type="Control" val="sub 35935939458:sheet">
+        <atom type="Label">Sphere-Ellipse</atom>
+        <atom type="Style">toolchoice</atom>
+        <atom type="Hash">35935939458:sheet</atom>
+      </list>
+      <list type="Control" val="sub 34739939461:sheet">
+        <atom type="Label">Cyl-Caps</atom>
+        <atom type="Style">toolchoice</atom>
+        <atom type="Hash">34739939461:sheet</atom>
+      </list>
+      <list type="Control" val="cmd tool.set &quot;prim.cone&quot; &quot;on&quot;">
+        <list type="AltCmd" val="script.run &quot;macro.scriptservice:47158810007:macro&quot;">
+          <atom type="AltCmdLabel">Unit Cone</atom>
+          <atom type="AltCmdQualifiers">ctrl</atom>
+        </list>
+        <list type="AltCmd" val="script.run &quot;macro.scriptservice:47158833888:macro&quot;">
+          <atom type="AltCmdLabel">Cone Item</atom>
+          <atom type="AltCmdQualifiers">shift</atom>
+        </list>
+        <atom type="Label">Cone</atom>
+        <atom type="Tooltip">@@3003</atom>
+      </list>
+      <list type="Control" val="cmd tool.set &quot;prim.toroid&quot; &quot;on&quot;">
+        <list type="AltCmd" val="script.run &quot;macro.scriptservice:45422360005:macro&quot;">
+          <atom type="AltCmdLabel">Unit Toroid</atom>
+          <atom type="AltCmdQualifiers">ctrl</atom>
+        </list>
+        <list type="AltCmd" val="script.run &quot;macro.scriptservice:45422344000:macro&quot;">
+          <atom type="AltCmdLabel">Toroid Item</atom>
+          <atom type="AltCmdQualifiers">shift</atom>
+        </list>
+        <atom type="Label">Toroid</atom>
+        <atom type="Tooltip">@@3000</atom>
+      </list>
+      <list type="Control" val="sub 75074939467:sheet">
+        <atom type="Label">VolumeDrawing</atom>
+        <atom type="Style">toolchoice</atom>
+        <atom type="Hash">75074939467:sheet</atom>
+      </list>
+      <list type="Control" val="sub 69578939470:sheet">
+        <atom type="Label">2D Drawing</atom>
+        <atom type="Style">toolchoice</atom>
+        <atom type="Hash">69578939470:sheet</atom>
+      </list>
+      <list type="Control" val="cmd script.run &quot;macro.scriptservice:32235733234:macro&quot;">
+        <list type="AltCmd" val="script.run &quot;macro.scriptservice:32235733444:macro&quot;">
+          <atom type="AltCmdLabel">Plane Item</atom>
+          <atom type="AltCmdQualifiers">shift</atom>
+        </list>
+        <atom type="Label">Plane Unit</atom>
+        <atom type="Tooltip">Plane Unit</atom>
+      <atom type="IconResource">etr_prm_plane</atom>
+      </list>
+      <list type="Control" val="sub 49433656994:sheet">
+        <atom type="Label">Allan Kiipli Primitives</atom>
+        <atom type="Tooltip">POPOVER - Allan Kiipli Primitives</atom>
+        <atom type="Style">popover</atom>
+      <atom type="IconImage">eterea_primitives/scripts/icons/dodecahedron.png</atom>
+      <atom type="IconResource">etr_prm_kiipli</atom>
+        <atom type="Hash">49433656994:sheet</atom>
+      </list>
+      <list type="Control" val="sub 85424396998:sheet">
+        <atom type="Label">Standard Primitives</atom>
+        <atom type="Tooltip">POPOVER - Standard Primitives</atom>
+        <atom type="Enable">0</atom>
+        <atom type="Style">popover</atom>
+      <atom type="IconImage">eterea_primitives/scripts/icons/thorus.png</atom>
+      <atom type="IconResource">etr_prm_standard</atom>
+        <atom type="Hash">85424396998:sheet</atom>
+      </list>
+    </hash>
+    <hash type="Sheet" key="35935939458:sheet">
+      <atom type="Label">Sphere-Ellipse</atom>
+      <atom type="Style">toolchoice</atom>
+      <list type="Control" val="cmd tool.set &quot;prim.sphere&quot; &quot;on&quot;">
+        <list type="AltCmd" val="script.run &quot;macro.scriptservice:19601440010:macro&quot;">
+          <atom type="AltCmdLabel">Unit Sphere</atom>
+          <atom type="AltCmdQualifiers">ctrl</atom>
+        </list>
+        <list type="AltCmd" val="script.run &quot;macro.scriptservice:19601433555:macro&quot;">
+          <atom type="AltCmdLabel">Sphere Item</atom>
+          <atom type="AltCmdQualifiers">shift</atom>
+        </list>
+        <atom type="Label">Sphere</atom>
+        <atom type="Tooltip">@@3000</atom>
+      </list>
+      <list type="Control" val="cmd tool.set &quot;prim.ellipsoid&quot; &quot;on&quot;">
+        <list type="AltCmd" val="script.run &quot;macro.scriptservice:57205200002:macro&quot;">
+          <atom type="AltCmdLabel">Unit Ellipsoid</atom>
+          <atom type="AltCmdQualifiers">ctrl</atom>
+        </list>
+        <list type="AltCmd" val="script.run &quot;macro.scriptservice:70538333999:macro&quot;">
+          <atom type="AltCmdLabel">Teapot Item</atom>
+          <atom type="AltCmdQualifiers">shift</atom>
+        </list>
+        <atom type="Label">Ellipsoid</atom>
+        <atom type="Tooltip">@@3001</atom>
+      </list>
+    </hash>
+    <hash type="Sheet" key="34739939461:sheet">
+      <atom type="Label">Cyl-Caps</atom>
+      <atom type="Style">toolchoice</atom>
+      <list type="Control" val="cmd tool.set &quot;prim.cylinder&quot; &quot;on&quot;">
+        <list type="AltCmd" val="script.run &quot;macro.scriptservice:27554320013:macro&quot;">
+          <atom type="AltCmdLabel">Unit Cylinder</atom>
+          <atom type="AltCmdQualifiers">ctrl</atom>
+        </list>
+        <list type="AltCmd" val="script.run &quot;macro.scriptservice:27554333777:macro&quot;">
+          <atom type="AltCmdLabel">Cylinder Item</atom>
+          <atom type="AltCmdQualifiers">shift</atom>
+        </list>
+        <atom type="Label">Cylinder</atom>
+        <atom type="Tooltip">@@3000</atom>
+      </list>
+      <list type="Control" val="cmd tool.set &quot;prim.capsule&quot; &quot;on&quot;">
+        <list type="AltCmd" val="script.run &quot;macro.scriptservice:55899040028:macro&quot;">
+          <atom type="AltCmdLabel">Unit Capsule</atom>
+          <atom type="AltCmdQualifiers">ctrl</atom>
+        </list>
+        <list type="AltCmd" val="script.run &quot;macro.scriptservice:55899044222:macro&quot;">
+          <atom type="AltCmdLabel">Capsule Item</atom>
+          <atom type="AltCmdQualifiers">shift</atom>
+        </list>
+        <atom type="Label">Capsule</atom>
+        <atom type="Tooltip">@@3001</atom>
+      </list>
+      <list type="Control" val="cmd tool.set &quot;prim.arc&quot; &quot;on&quot;">
+        <atom type="Label">Arc</atom>
+        <atom type="Tooltip">@@3002</atom>
+      </list>
+    </hash>
+    <hash type="Sheet" key="75074939467:sheet">
+      <atom type="Label">VolumeDrawing</atom>
+      <atom type="Style">toolchoice</atom>
+      <list type="Control" val="cmd tool.set &quot;prim.tube&quot; &quot;on&quot;">
+        <list type="AltCmd" val="script.run &quot;macro.scriptservice:32235733444:macro&quot;">
+          <atom type="AltCmdLabel">Plane Item</atom>
+          <atom type="AltCmdQualifiers">shift</atom>
+        </list>
+        <atom type="Label">Tube</atom>
+        <atom type="Tooltip">@@3000</atom>
+      </list>
+      <list type="Control" val="cmd tool.set &quot;SS Default&quot; 1">
+        <atom type="Tooltip">@@3001</atom>
+      </list>
+    </hash>
+    <hash type="Sheet" key="69578939470:sheet">
+      <atom type="Label">2D Drawing</atom>
+      <atom type="Style">toolchoice</atom>
+      <list type="Control" val="cmd tool.set &quot;prim.pen&quot; &quot;on&quot; &quot;0&quot;">
+        <atom type="Label">Pen</atom>
+        <atom type="Tooltip">@@3000</atom>
+      </list>
+      <list type="Control" val="cmd tool.set prim.curve 1">
+        <atom type="Tooltip">@@3001</atom>
+      </list>
+      <list type="Control" val="cmd tool.set prim.bspline 1">
+        <atom type="Label">B-Spline</atom>
+        <atom type="Tooltip">@@3005</atom>
+      </list>
+      <list type="Control" val="cmd tool.set prim.bezier 1">
+        <atom type="Tooltip">@@3002</atom>
+      </list>
+      <list type="Control" val="cmd tool.set prim.sketch 1">
+        <atom type="Tooltip">@@3003</atom>
+      </list>
+      <list type="Control" val="cmd tool.set patch.draw 1">
+        <atom type="Label">Patch Curves</atom>
+        <atom type="Tooltip">@@3004</atom>
+      </list>
+    </hash>
+    <hash type="Sheet" key="49433656994:sheet">
+      <atom type="Label">Allan Kiipli Primitives</atom>
+      <atom type="Tooltip">POPOVER - Allan Kiipli Primitives</atom>
+      <atom type="Style">popover</atom>
+      <atom type="Layout">vtoolbar</atom>
+      <atom type="IconMode">both</atom>
+      <atom type="IconSize">large</atom>
+      <atom type="IconImage">eterea_primitives/scripts/icons/dodecahedron.png</atom>
+      <atom type="IconResource">etr_prm_kiipli</atom>
+      <list type="Control" val="cmd @dodecahedron.pl">
+        <atom type="Label">Dodecahedron</atom>
+        <atom type="Tooltip">A bunch of UV ready polyhedron created by Allan Kiipli. All edges are 1 m length, except Rhombic Triacontahedron (this one can serve as a construction wireframe for spacetessellative dodecahedron and icosahedron)</atom>
+      <atom type="IconResource">etr_prm_dodecahedron</atom>
+      </list>
+      <list type="Control" val="cmd @fullerenmolecule.pl">
+        <atom type="Label">Fullerenmolecule</atom>
+        <atom type="Tooltip">A bunch of UV ready polyhedron created by Allan Kiipli. All edges are 1 m length, except Rhombic Triacontahedron (this one can serve as a construction wireframe for spacetessellative dodecahedron and icosahedron)</atom>
+      <atom type="IconResource">etr_prm_fullerenmolecule</atom>
+      </list>
+      <list type="Control" val="cmd @icosahedron.pl">
+        <atom type="Label">Icosahedron</atom>
+        <atom type="Tooltip">A bunch of UV ready polyhedron created by Allan Kiipli. All edges are 1 m length, except Rhombic Triacontahedron (this one can serve as a construction wireframe for spacetessellative dodecahedron and icosahedron)</atom>
+      <atom type="IconResource">etr_prm_icosahedron</atom>
+      </list>
+      <list type="Control" val="cmd @icosidodecahedron.pl">
+        <atom type="Label">Icosidodecahedron</atom>
+        <atom type="Tooltip">A bunch of UV ready polyhedron created by Allan Kiipli. All edges are 1 m length, except Rhombic Triacontahedron (this one can serve as a construction wireframe for spacetessellative dodecahedron and icosahedron)</atom>
+      <atom type="IconResource">etr_prm_icosidodecahedron</atom>
+      </list>
+      <list type="Control" val="cmd @pinned_dodecahedron.pl">
+        <atom type="Label">Pinned Dodecahedron</atom>
+        <atom type="Tooltip">A bunch of UV ready polyhedron created by Allan Kiipli. All edges are 1 m length, except Rhombic Triacontahedron (this one can serve as a construction wireframe for spacetessellative dodecahedron and icosahedron)</atom>
+      <atom type="IconResource">etr_prm_pinned_dodecahedron</atom>
+      </list>
+      <list type="Control" val="cmd @rhombic_dodecahedron.pl">
+        <atom type="Label">Rhombic Dodecahedron</atom>
+        <atom type="Tooltip">A bunch of UV ready polyhedron created by Allan Kiipli. All edges are 1 m length, except Rhombic Triacontahedron (this one can serve as a construction wireframe for spacetessellative dodecahedron and icosahedron)</atom>
+      <atom type="IconResource">etr_prm_rhombic_dodecahedron</atom>
+      </list>
+      <list type="Control" val="cmd @rhombic_triacontahedron.pl">
+        <atom type="Label">Rhombic Triacontahedron</atom>
+        <atom type="Tooltip">A bunch of UV ready polyhedron created by Allan Kiipli. All edges are 1 m length, except Rhombic Triacontahedron (this one can serve as a construction wireframe for spacetessellative dodecahedron and icosahedron)</atom>
+      <atom type="IconResource">etr_prm_rhombic_triacontahedron</atom>
+      </list>
+      <list type="Control" val="cmd @snubdodecahedron.pl">
+        <atom type="Label">Snubdodecahedron</atom>
+        <atom type="Tooltip">A bunch of UV ready polyhedron created by Allan Kiipli. All edges are 1 m length, except Rhombic Triacontahedron (this one can serve as a construction wireframe for spacetessellative dodecahedron and icosahedron)</atom>
+      <atom type="IconResource">etr_prm_snubdodecahedron</atom>
+      </list>
+    </hash>
+    <hash type="Sheet" key="85424396998:sheet">
+      <atom type="Label">Standard Primitives</atom>
+      <atom type="Tooltip">POPOVER - Standard Primitives</atom>
+      <atom type="Enable">0</atom>
+      <atom type="Style">popover</atom>
+      <atom type="Layout">vtoolbar</atom>
+      <atom type="IconMode">both</atom>
+      <atom type="IconSize">large</atom>
+      <atom type="IconImage">eterea_primitives/scripts/icons/thorus.png</atom>
+      <atom type="IconResource">etr_prm_standard</atom>
+      <list type="Control" val="cmd tool.set &quot;prim.cube&quot; &quot;on&quot;">
+        <list type="AltCmd" val="script.run &quot;macro.scriptservice:32235710027:macro&quot;">
+          <atom type="AltCmdLabel">Unit Cube</atom>
+          <atom type="AltCmdQualifiers">ctrl</atom>
+        </list>
+        <list type="AltCmd" val="script.run &quot;macro.scriptservice:32235733333:macro&quot;">
+          <atom type="AltCmdLabel">Cube Item</atom>
+          <atom type="AltCmdQualifiers">shift</atom>
+        </list>
+        <atom type="Label">Cube</atom>
+        <atom type="Tooltip">Cube</atom>
+      </list>
+      <list type="Control" val="cmd tool.set &quot;prim.sphere&quot; &quot;on&quot;">
+        <list type="AltCmd" val="script.run &quot;macro.scriptservice:19601440010:macro&quot;">
+          <atom type="AltCmdLabel">Unit Sphere</atom>
+          <atom type="AltCmdQualifiers">ctrl</atom>
+        </list>
+        <list type="AltCmd" val="script.run &quot;macro.scriptservice:19601433555:macro&quot;">
+          <atom type="AltCmdLabel">Sphere Item</atom>
+          <atom type="AltCmdQualifiers">shift</atom>
+        </list>
+        <atom type="Label">Sphere</atom>
+        <atom type="Tooltip">Sphere</atom>
+      </list>
+      <list type="Control" val="cmd tool.set &quot;prim.ellipsoid&quot; &quot;on&quot;">
+        <list type="AltCmd" val="script.run &quot;macro.scriptservice:57205200002:macro&quot;">
+          <atom type="AltCmdLabel">Unit Ellipsoid</atom>
+          <atom type="AltCmdQualifiers">ctrl</atom>
+        </list>
+        <list type="AltCmd" val="script.run &quot;macro.scriptservice:70538333999:macro&quot;">
+          <atom type="AltCmdLabel">Teapot Item</atom>
+          <atom type="AltCmdQualifiers">shift</atom>
+        </list>
+        <atom type="Label">Ellipsoid</atom>
+        <atom type="Tooltip">Ellipsoid</atom>
+      </list>
+      <list type="Control" val="cmd tool.set &quot;prim.cylinder&quot; &quot;on&quot;">
+        <list type="AltCmd" val="script.run &quot;macro.scriptservice:27554320013:macro&quot;">
+          <atom type="AltCmdLabel">Unit Cylinder</atom>
+          <atom type="AltCmdQualifiers">ctrl</atom>
+        </list>
+        <list type="AltCmd" val="script.run &quot;macro.scriptservice:27554333777:macro&quot;">
+          <atom type="AltCmdLabel">Cylinder Item</atom>
+          <atom type="AltCmdQualifiers">shift</atom>
+        </list>
+        <atom type="Label">Cylinder</atom>
+        <atom type="Tooltip">Cylinder</atom>
+      </list>
+      <list type="Control" val="cmd tool.set &quot;prim.capsule&quot; &quot;on&quot;">
+        <list type="AltCmd" val="script.run &quot;macro.scriptservice:55899040028:macro&quot;">
+          <atom type="AltCmdLabel">Unit Capsule</atom>
+          <atom type="AltCmdQualifiers">ctrl</atom>
+        </list>
+        <list type="AltCmd" val="script.run &quot;macro.scriptservice:55899044222:macro&quot;">
+          <atom type="AltCmdLabel">Capsule Item</atom>
+          <atom type="AltCmdQualifiers">shift</atom>
+        </list>
+        <atom type="Label">Capsule</atom>
+        <atom type="Tooltip">Capsule</atom>
+      </list>
+      <list type="Control" val="cmd tool.set &quot;prim.cone&quot; &quot;on&quot;">
+        <list type="AltCmd" val="script.run &quot;macro.scriptservice:47158810007:macro&quot;">
+          <atom type="AltCmdLabel">Unit Cone</atom>
+          <atom type="AltCmdQualifiers">ctrl</atom>
+        </list>
+        <list type="AltCmd" val="script.run &quot;macro.scriptservice:47158833888:macro&quot;">
+          <atom type="AltCmdLabel">Cone Item</atom>
+          <atom type="AltCmdQualifiers">shift</atom>
+        </list>
+        <atom type="Label">Cone</atom>
+        <atom type="Tooltip">Cone</atom>
+      </list>
+      <list type="Control" val="cmd tool.set &quot;prim.toroid&quot; &quot;on&quot;">
+        <list type="AltCmd" val="script.run &quot;macro.scriptservice:45422360005:macro&quot;">
+          <atom type="AltCmdLabel">Unit Toroid</atom>
+          <atom type="AltCmdQualifiers">ctrl</atom>
+        </list>
+        <list type="AltCmd" val="script.run &quot;macro.scriptservice:45422344000:macro&quot;">
+          <atom type="AltCmdLabel">Toroid Item</atom>
+          <atom type="AltCmdQualifiers">shift</atom>
+        </list>
+        <atom type="Label">Toroid</atom>
+        <atom type="Tooltip">Toroid</atom>
+      </list>
+      <list type="Control" val="cmd tool.set eterea.prim.tube on">
+        <atom type="Label">Tube</atom>
+        <atom type="Tooltip">Tube</atom>
+      <atom type="IconResource">etr_prm_tube</atom>
+      </list>
+      <list type="Control" val="cmd tool.set &quot;SS Default&quot; 1">
+        <atom type="Label">Solid Sketch</atom>
+        <atom type="Tooltip">Solid Sketch</atom>
+      </list>
+      <list type="Control" val="cmd tool.set &quot;prim.text&quot; &quot;on&quot;">
+        <atom type="Label">Text</atom>
+        <atom type="Tooltip">Text</atom>
+      </list>
+    </hash>
+  </atom>
+</configuration>

--- a/Configs/Falloff Pie.CFG
+++ b/Configs/Falloff Pie.CFG
@@ -1,0 +1,69 @@
+<?xml version="1.0"?>
+<configuration>
+  <atom type="Attributes">
+    <hash type="Sheet" key="96296886562:sheet">
+      <atom type="Label">Falloffs</atom>
+      <atom type="Style">pie</atom>
+      <atom type="EditorColor">786432</atom>
+      <atom type="Group">piemenus</atom>
+      <list type="Control" val="cmd tool.clearTask falloff">
+        <atom type="Label">Clear Falloffs</atom>
+      </list>
+      <list type="Control" val="cmd tool.set falloff.linear on">
+        <atom type="Label">Linear</atom>
+      </list>
+      <list type="Control" val="cmd tool.set falloff.radial on">
+        <atom type="Label">Radial</atom>
+      </list>
+      <list type="Control" val="cmd tool.set &quot;falloff.noise&quot; &quot;on&quot;">
+        <atom type="Label">Noise</atom>
+      </list>
+      <list type="Control" val="sub 66102395007:sheet">
+        <atom type="Label">More Falloff...</atom>
+        <atom type="Style">pie</atom>
+        <atom type="Hash">66102395007:sheet</atom>
+      </list>
+      <list type="Control" val="cmd tool.set &quot;falloff.selection&quot; &quot;on&quot;">
+        <atom type="Label">Selection</atom>
+      </list>
+      <list type="Control" val="cmd tool.set falloff.softSelection on">
+        <atom type="Label">Soft Selection</atom>
+      </list>
+      <list type="Control" val="cmd tool.set falloff.invert add falloff">
+        <atom type="Label">Invert</atom>
+      </list>
+    </hash>
+    <hash type="Sheet" key="66102395007:sheet">
+      <atom type="Label">More Falloff...</atom>
+      <atom type="Style">pie</atom>
+      <list type="Control" val="cmd tool.set falloff.element on">
+        <atom type="Label">Element</atom>
+      </list>
+      <list type="Control" val="cmd tool.set falloff.cylinder on">
+        <atom type="Label">Cylinder</atom>
+      </list>
+      <list type="Control" val="cmd tool.set falloff.airbrush on">
+        <atom type="Label">Airbrush</atom>
+      </list>
+      <list type="Control" val="cmd tool.set falloff.screen on">
+        <atom type="Label">Screen</atom>
+      </list>
+      <list type="Control" val="cmd tool.set &quot;falloff.curvature&quot; &quot;on&quot;">
+        <atom type="Label">Curvature</atom>
+      </list>
+      <list type="Control" val="cmd tool.set falloff.vertexMap on">
+        <atom type="Label">Vertex Map</atom>
+      </list>
+      <list type="Control" val="cmd tool.set &quot;PathFalloff&quot; &quot;on&quot;">
+        <atom type="Label">Path</atom>
+      </list>
+      <list type="Control" val="cmd tool.set &quot;falloff.lasso&quot; &quot;on&quot;">
+        <atom type="Label">Lasso</atom>
+      </list>
+      <list type="Control" val="cmd tool.set &quot;falloff.image&quot; &quot;on&quot;">
+        <atom type="Label">Image</atom>
+        <atom type="Enable">0</atom>
+      </list>
+    </hash>
+  </atom>
+</configuration>

--- a/Configs/GooseBig's 3D Context Modeling Operation Menu.CFG
+++ b/Configs/GooseBig's 3D Context Modeling Operation Menu.CFG
@@ -1,0 +1,183 @@
+<?xml version="1.0"?>
+<configuration>
+  <atom type="Attributes">
+    <hash type="Sheet" key="15119731657:sheet">
+      <atom type="Label">_Edge Context Menu</atom>
+      <atom type="Style">inline</atom>
+      <atom type="EditorColor">65536</atom>
+      <atom type="Filter">3D Context Menu: Edges</atom>
+      <atom type="Group">contextmenus/view3d/GooseBig's 3D Context Moedeling Operation Menu</atom>
+      <hash type="InCategory" key="36715731631:sheet#head">
+        <atom type="Ordinal">53.48</atom>
+      </hash>
+      <list type="Control" val="cmd tool.set edge.bevel on">
+        <atom type="Label">Bevel</atom>
+      </list>
+      <list type="Control" val="cmd tool.set edge.extrude on">
+        <atom type="Label">Extrude</atom>
+      </list>
+      <list type="Control" val="cmd tool.set edge.extend on">
+        <atom type="Label">Extend</atom>
+      </list>
+      <list type="Control" val="cmd tool.set EdgeSlide on">
+        <atom type="Label">Slide</atom>
+      </list>
+      <list type="Control" val="cmd tool.set edge.bridge on">
+        <atom type="Label">Bridge</atom>
+      </list>
+      <list type="Control" val="cmd script.run &quot;macro.scriptservice:3223571edge:macro&quot;">
+        <atom type="Label">Edge Weight</atom>
+      </list>
+      <list type="Control" val="div ">
+        <atom type="Hash">13167731709:control</atom>
+      </list>
+      <list type="Control" val="cmd edge.spinQuads">
+        <atom type="Label">Spin</atom>
+      </list>
+      <list type="Control" val="cmd edge.remove">
+        <atom type="Label">Remove</atom>
+      </list>
+      <list type="Control" val="cmd edge.collapse">
+        <atom type="Label">Collapse</atom>
+      </list>
+      <list type="Control" val="cmd edge.join">
+        <atom type="Label">Join</atom>
+      </list>
+      <list type="Control" val="cmd edge.split">
+        <atom type="Label">Split</atom>
+      </list>
+      <list type="Control" val="cmd edge.growQuads">
+        <atom type="Label">Grow Quads</atom>
+      </list>
+      <list type="Control" val="cmd edge.fillQuads">
+        <atom type="Label">Fill Quads</atom>
+      </list>
+      <list type="Control" val="cmd edge.splitNormals">
+        <atom type="Label">Split Normals</atom>
+      </list>
+      <list type="Control" val="cmd edges.toCurves">
+        <atom type="Label">Edges to Curves</atom>
+      </list>
+    </hash>
+    <hash type="Sheet" key="42988731684:sheet">
+      <atom type="Label">_Polygon Context Menu</atom>
+      <atom type="Style">inline</atom>
+      <atom type="EditorColor">65536</atom>
+      <atom type="Filter">3D Context Menu: Polygons</atom>
+      <atom type="Group">contextmenus/view3d/GooseBig's 3D Context Moedeling Operation Menu</atom>
+      <hash type="InCategory" key="36715731631:sheet#head">
+        <atom type="Ordinal">52.53</atom>
+      </hash>
+      <list type="Control" val="cmd tool.set poly.bevel on">
+        <atom type="Label">Bevel</atom>
+      </list>
+      <list type="Control" val="cmd tool.set poly.extrude on">
+        <atom type="Label">Extrude</atom>
+      </list>
+      <list type="Control" val="cmd tool.set poly.sweep on">
+        <atom type="Label">Sketch Extrude</atom>
+      </list>
+      <list type="Control" val="cmd tool.set SlideSelect on">
+        <atom type="Label">Slide</atom>
+      </list>
+      <list type="Control" val="cmd tool.set edge.bridge on">
+        <atom type="Label">Bridge</atom>
+      </list>
+      <list type="Control" val="cmd tool.set poly.smshift on">
+        <atom type="Label">Smooth Shift</atom>
+      </list>
+      <list type="Control" val="cmd tool.set poly.shift on">
+        <atom type="Label">Shift</atom>
+      </list>
+      <list type="Control" val="cmd tool.set poly.inset on">
+        <atom type="Label">Inset</atom>
+      </list>
+      <list type="Control" val="div ">
+        <atom type="Hash">36231731828:control</atom>
+      </list>
+      <list type="Control" val="cmd poly.remove">
+        <atom type="Label">Remove</atom>
+      </list>
+      <list type="Control" val="cmd poly.collapse">
+        <atom type="Label">Collapse</atom>
+      </list>
+      <list type="Control" val="cmd poly.unify">
+        <atom type="Label">Unify</atom>
+      </list>
+      <list type="Control" val="cmd poly.merge">
+        <atom type="Label">Merge</atom>
+      </list>
+      <list type="Control" val="cmd poly.flip">
+        <atom type="Label">Flip</atom>
+      </list>
+      <list type="Control" val="cmd poly.spinQuads">
+        <atom type="Label">Spin</atom>
+      </list>
+      <list type="Control" val="cmd poly.triple">
+        <atom type="Label">Triple</atom>
+      </list>
+      <list type="Control" val="cmd tool.set Thicken on">
+        <atom type="Label">Thicken</atom>
+      </list>
+      <list type="Control" val="cmd select.boundary">
+        <atom type="Label">+Bounds</atom>
+      </list>
+      <list type="Control" val="cmd script.run &quot;macro.scriptservice:92663570022:macro&quot;">
+        <atom type="Label">Convert2Bounds</atom>
+      </list>
+    </hash>
+    <hash type="Sheet" key="36715731631:sheet">
+      <atom type="Label">_Universal 3D Context Moedling Operation</atom>
+      <atom type="Desc">Hotkey = space (registered in GooseBig's InputRemapping.CFG)</atom>
+      <atom type="Style">popup</atom>
+      <atom type="EditorColor">786432</atom>
+      <atom type="Group">contextmenus/view3d/GooseBig's 3D Context Moedeling Operation Menu</atom>
+    </hash>
+    <hash type="Sheet" key="33327731672:sheet">
+      <atom type="Label">_Vertex Context Menu</atom>
+      <atom type="Style">inline</atom>
+      <atom type="EditorColor">65536</atom>
+      <atom type="Filter">3D Context Menu: Vertices</atom>
+      <atom type="Group">contextmenus/view3d/GooseBig's 3D Context Moedeling Operation Menu</atom>
+      <hash type="InCategory" key="36715731631:sheet#head">
+        <atom type="Ordinal">49.50.55</atom>
+      </hash>
+      <list type="Control" val="cmd tool.set vert.bevel on">
+        <atom type="Label">Bevel</atom>
+      </list>
+      <list type="Control" val="cmd tool.set vert.extrude on">
+        <atom type="Label">Extrude</atom>
+      </list>
+      <list type="Control" val="cmd tool.set SlideSelect on">
+        <atom type="Label">Slide</atom>
+      </list>
+      <list type="Control" val="div ">
+        <atom type="Hash">41132731868:control</atom>
+      </list>
+      <list type="Control" val="cmd vert.remove">
+        <atom type="Label">Remove</atom>
+      </list>
+      <list type="Control" val="cmd vert.collapse">
+        <atom type="Label">Collapse</atom>
+      </list>
+      <list type="Control" val="cmd vert.split">
+        <atom type="Label">Split Vertex</atom>
+      </list>
+      <list type="Control" val="cmd poly.split">
+        <atom type="Label">Split Polygon</atom>
+      </list>
+      <list type="Control" val="cmd vert.merge">
+        <atom type="Label">Merge</atom>
+      </list>
+      <list type="Control" val="cmd vert.join">
+        <atom type="Label">Join</atom>
+      </list>
+      <list type="Control" val="cmd vert.center">
+        <atom type="Label">Center</atom>
+      </list>
+      <list type="Control" val="cmd vert.align">
+        <atom type="Label">Align</atom>
+      </list>
+    </hash>
+  </atom>
+</configuration>

--- a/Configs/GooseBig's Duplicate and Instance Pies.CFG
+++ b/Configs/GooseBig's Duplicate and Instance Pies.CFG
@@ -1,0 +1,137 @@
+<?xml version="1.0"?>
+<configuration>
+  <atom type="Attributes">
+    <hash type="Sheet" key="13945780621:sheet">
+      <atom type="Label">Duplicate Operation Pie</atom>
+      <atom type="Desc">Hotkey = alt-d (registered in GooseBig's InputRemapping.CFG)
+
+#this hotkey conflict with QQ's default setting</atom>
+      <atom type="Style">pie</atom>
+      <atom type="EditorColor">786432</atom>
+      <atom type="Group">piemenus</atom>
+      <list type="Control" val="cmd tool.set &quot;*.mirror&quot; &quot;on&quot;">
+        <atom type="Label">Mirror</atom>
+      </list>
+      <list type="Control" val="cmd tool.set &quot;*.clone&quot; &quot;on&quot;">
+        <atom type="Label">Clone</atom>
+      </list>
+      <list type="Control" val="cmd tool.set &quot;*.array&quot; &quot;on&quot;">
+        <atom type="Label">Array</atom>
+      </list>
+      <list type="Control" val="cmd tool.set &quot;*.Radial Array&quot; &quot;on&quot;">
+        <atom type="Label">Radial Array</atom>
+      </list>
+      <list type="Control" val="sub 87157782409:sheet">
+        <atom type="Label">Curve Clone</atom>
+        <atom type="Style">pie</atom>
+        <atom type="Hash">87157782409:sheet</atom>
+      </list>
+      <list type="Control" val="cmd tool.set &quot;*.Scatter Clone&quot; &quot;on&quot;">
+        <atom type="Label">Scatter Clone</atom>
+      </list>
+      <list type="Control" val="cmd tool.set &quot;*.Mesh Paint Smooth&quot; &quot;on&quot;">
+        <atom type="Label">Mesh Paint</atom>
+      </list>
+      <list type="Control" val="cmd tool.set &quot;Radial Sweep&quot; &quot;on&quot;">
+        <atom type="Label">Radial Sweep</atom>
+      </list>
+      <list type="Control" val="sub 00042782266:sheet">
+        <atom type="Label">Curve Extrude</atom>
+        <atom type="Style">pie</atom>
+        <atom type="Hash">00042782266:sheet</atom>
+      </list>
+    </hash>
+    <hash type="Sheet" key="87157782409:sheet">
+      <atom type="Label">Curve Clone</atom>
+      <atom type="Style">pie</atom>
+      <list type="Control" val="cmd tool.set &quot;*.Curve Clone&quot; &quot;on&quot;">
+        <list type="AltCmd" val="tool.set &quot;Curve Instance&quot; on">
+          <atom type="AltCmdLabel">Curve Instance</atom>
+          <atom type="AltCmdQualifiers">alt</atom>
+        </list>
+        <atom type="Label">Curve Clone</atom>
+        <atom type="Tooltip">@@3000</atom>
+      </list>
+      <list type="Control" val="cmd tool.set &quot;*.Bezier Clone&quot; &quot;on&quot;">
+        <atom type="Label">Bezier Clone</atom>
+        <atom type="Tooltip">@@3004</atom>
+      </list>
+      <list type="Control" val="cmd tool.set &quot;*.BSpline Clone&quot; &quot;on&quot;">
+        <atom type="Label">B-Spline Clone</atom>
+        <atom type="Tooltip">@@3004</atom>
+      </list>
+      <list type="Control" val="cmd tool.set &quot;*.Pen Clone&quot; &quot;on&quot;">
+        <atom type="Label">Pen Clone</atom>
+        <atom type="Tooltip">@@3008</atom>
+      </list>
+    </hash>
+    <hash type="Sheet" key="00042782266:sheet">
+      <atom type="Label">Curve Extrude</atom>
+      <atom type="Style">pie</atom>
+      <list type="Control" val="cmd tool.set &quot;Curve Extrude&quot; &quot;on&quot;">
+        <atom type="Label">Curve Extrude</atom>
+      </list>
+      <list type="Control" val="cmd tool.set &quot;Bezier Extrude&quot; &quot;on&quot;">
+        <atom type="Label">Bezier Extrude</atom>
+      </list>
+      <list type="Control" val="cmd tool.set &quot;BSpline Extrude&quot; &quot;on&quot;">
+        <atom type="Label">BSpline Extrude</atom>
+      </list>
+      <list type="Control" val="cmd tool.set &quot;Pen Extrude&quot; &quot;on&quot;">
+        <atom type="Label">Pen Extrude</atom>
+      </list>
+    </hash>
+    <hash type="Sheet" key="15591781406:sheet">
+      <atom type="Label">Instance Operation Pie</atom>
+      <atom type="Desc">Hotkey = ctrl-alt-d (registered in GooseBig's InputRemapping.CFG)
+
+#this hotkey conflict with QQ's default setting</atom>
+      <atom type="Style">pie</atom>
+      <atom type="EditorColor">786432</atom>
+      <atom type="Group">piemenus</atom>
+      <list type="Control" val="cmd tool.set &quot;Instance Mirror&quot; 1">
+        <atom type="Label">Mirror Inst</atom>
+      </list>
+      <list type="Control" val="cmd tool.set &quot;Instance Clone&quot; 1">
+        <atom type="Label">Clone Inst</atom>
+      </list>
+      <list type="Control" val="cmd tool.set &quot;Instance Array&quot; 1">
+        <atom type="Label">Array Inst</atom>
+      </list>
+      <list type="Control" val="cmd tool.set &quot;Instance Radial Array&quot; &quot;on&quot;">
+        <atom type="Label">Radial Array Inst</atom>
+      </list>
+      <list type="Control" val="sub 99264782419:sheet">
+        <atom type="Label">Curve Inst</atom>
+        <atom type="Style">pie</atom>
+        <atom type="Hash">99264782419:sheet</atom>
+      </list>
+      <list type="Control" val="cmd tool.set &quot;Instance Scatter&quot; &quot;on&quot;">
+        <atom type="Label">Scatter Inst</atom>
+      </list>
+      <list type="Control" val="cmd tool.set &quot;Mesh Paint Instance&quot; &quot;on&quot;">
+        <atom type="Label">Mesh Paint Inst</atom>
+      </list>
+    </hash>
+    <hash type="Sheet" key="99264782419:sheet">
+      <atom type="Label">Curve Inst</atom>
+      <atom type="Style">pie</atom>
+      <list type="Control" val="cmd tool.set &quot;Curve Instance&quot; on">
+        <atom type="Label">Curve Instance</atom>
+        <atom type="Tooltip">@@3001</atom>
+      </list>
+      <list type="Control" val="cmd tool.set &quot;Bezier Instance&quot; &quot;on&quot;">
+        <atom type="Label">Bezier Instance</atom>
+        <atom type="Tooltip">@@3005</atom>
+      </list>
+      <list type="Control" val="cmd tool.set &quot;BSpline Instance&quot; &quot;on&quot;">
+        <atom type="Label">B-Spline Instance</atom>
+        <atom type="Tooltip">@@3005</atom>
+      </list>
+      <list type="Control" val="cmd tool.set &quot;Pen Instance&quot; &quot;on&quot;">
+        <atom type="Label">Pen Instance</atom>
+        <atom type="Tooltip">@@3009</atom>
+      </list>
+    </hash>
+  </atom>
+</configuration>

--- a/Configs/GooseBig's InputRemapping.CFG
+++ b/Configs/GooseBig's InputRemapping.CFG
@@ -1,0 +1,393 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+  <atom type="InputRemapping">
+
+	<!-- ********************************* -->
+	<!-- Tool specific hot keys -->
+	<!-- ********************************* -->
+	
+	<!-- VERT BEVEL -->
+		<hash type="Region" key="view3DTools+toolPreset.vert.bevel+.anywhere@d">tool.attr vert.bevel level ?+</hash>
+		<hash type="Region" key="view3DTools+toolPreset.vert.bevel+.anywhere@a">tool.attr vert.bevel level ?-</hash>
+	<!--  -->
+	
+	<!-- Edge Bevel -->
+		<hash type="Region" key="view3DTools+toolPreset.edge.bevel+.anywhere@up">tool.attr edge.bevel level ?+</hash>
+		<hash type="Region" key="view3DTools+toolPreset.edge.bevel+.anywhere@down">tool.attr edge.bevel level ?-</hash>
+		<hash type="Region" key="view3DTools+toolPreset.edge.bevel+.anywhere@d">tool.attr edge.bevel level ?+</hash>
+		<hash type="Region" key="view3DTools+toolPreset.edge.bevel+.anywhere@a">tool.attr edge.bevel level ?-</hash>
+		<hash type="Region" key="view3DTools+toolPreset.edge.bevel+.anywhere@mouse5">tool.attr edge.bevel level ?+</hash>
+		<hash type="Region" key="view3DTools+toolPreset.edge.bevel+.anywhere@mouse4">tool.attr edge.bevel level ?-</hash>
+		<hash type="Region" key="view3DTools+toolPreset.edge.bevel+.anywhere@e">tool.attr edge.bevel shape ?(square|round)</hash>
+	<!-- -->
+	
+	<!-- POLY BEVEL -->
+		<hash type="Region" key="view3DTools+toolPreset.poly.bevel+.anywhere@up">tool.attr poly.bevel segs ?+</hash>
+		<hash type="Region" key="view3DTools+toolPreset.poly.bevel+.anywhere@down">tool.attr poly.bevel segs ?-</hash>
+		<hash type="Region" key="view3DTools+toolPreset.poly.bevel+.anywhere@d">tool.attr poly.bevel segs ?+</hash>
+		<hash type="Region" key="view3DTools+toolPreset.poly.bevel+.anywhere@a">tool.attr poly.bevel segs ?-</hash>
+		<hash type="Region" key="view3DTools+toolPreset.poly.bevel+.anywhere@mouse5">tool.attr poly.bevel segs ?+</hash>
+		<hash type="Region" key="view3DTools+toolPreset.poly.bevel+.anywhere@mouse4">tool.attr poly.bevel segs ?-</hash>
+	<!--  -->
+	
+	<!-- MIRROR -->
+		<hash type="Region" key="view3DTools+toolPreset.gen.mirror+.anywhere@r">tool.reset gen.mirror</hash>
+		<!-- use z key to loop axises instead of useing x,y,z three keys-->
+		<hash type="Region" key="view3DTools+toolPreset.gen.mirror+.anywhere@z">tool.attr gen.mirror axis ?(0|1|2)</hash>
+		<!-- 
+		<hash type="Region" key="view3DTools+toolPreset.gen.mirror+.anywhere@x">tool.attr gen.mirror axis 0</hash>
+		<hash type="Region" key="view3DTools+toolPreset.gen.mirror+.anywhere@y">tool.attr gen.mirror axis 1</hash>
+		<hash type="Region" key="view3DTools+toolPreset.gen.mirror+.anywhere@z">tool.attr gen.mirror axis 2</hash>		
+		-->
+	<!-- -->
+	
+	<!-- Clone Effector -->
+		<!-- backquote is the key under Esc key -->
+		<hash type="Region" key="view3DTools+toolPreset.effector.clone+.anywhere@ctrl-backquote">tool.reset effector.clone</hash>
+		<hash type="Region" key="view3DTools+toolPreset.effector.clone+.anywhere@m">tool.attr effector.clone merge ?+</hash>
+	<!-- -->
+	
+	<!-- CLONE -->
+		<!-- backquote is the key under Esc key -->
+		<hash type="Region" key="view3DTools+toolPreset.gen.linear+.anywhere@shift-backquote">tool.reset gen.linear</hash>
+		<hash type="Region" key="view3DTools+toolPreset.gen.linear+.anywhere@up">tool.attr gen.linear num ?+</hash>
+		<hash type="Region" key="view3DTools+toolPreset.gen.linear+.anywhere@down">tool.attr gen.linear num ?-</hash>
+		<hash type="Region" key="view3DTools+toolPreset.gen.linear+.anywhere@d">tool.attr gen.linear num ?+</hash>
+		<hash type="Region" key="view3DTools+toolPreset.gen.linear+.anywhere@a">tool.attr gen.linear num ?-</hash>
+		<hash type="Region" key="view3DTools+toolPreset.gen.linear+.anywhere@mouse5">tool.attr gen.linear num ?+</hash>
+		<hash type="Region" key="view3DTools+toolPreset.gen.linear+.anywhere@mouse4">tool.attr gen.linear num ?-</hash>
+	<!-- -->
+	
+	<!-- Array Clone -->
+		<!-- backquote is the key under Esc key -->
+		<hash type="Region" key="view3DTools+toolPreset.gen.array+.anywhere@shift-backquote">tool.reset gen.array</hash>
+		<hash type="Region" key="view3DTools+toolPreset.gen.array+.anywhere@shift-x">tool.attr gen.array numX ?+</hash>
+		<hash type="Region" key="view3DTools+toolPreset.gen.array+.anywhere@shift-y">tool.attr gen.array numY ?+</hash>
+		<hash type="Region" key="view3DTools+toolPreset.gen.array+.anywhere@shift-z">tool.attr gen.array numZ ?+</hash>
+		<hash type="Region" key="view3DTools+toolPreset.gen.array+.anywhere@alt-x">tool.attr gen.array numX ?-</hash>
+		<hash type="Region" key="view3DTools+toolPreset.gen.array+.anywhere@alt-y">tool.attr gen.array numY ?-</hash>
+		<hash type="Region" key="view3DTools+toolPreset.gen.array+.anywhere@alt-z">tool.attr gen.array numZ ?-</hash>
+		<hash type="Region" key="view3DTools+toolPreset.gen.array+.anywhere@b">tool.attr gen.array between ?+</hash>
+	<!-- -->
+	
+	<!-- RADIAL ARRAY -->
+		<hash type="Region" key="view3DTools+toolPreset.gen.helix+.anywhere@shift-backquote">tool.reset gen.helix</hash>
+		<hash type="Region" key="view3DTools+toolPreset.gen.helix+.anywhere@up">tool.attr gen.helix sides ?+</hash>
+		<hash type="Region" key="view3DTools+toolPreset.gen.helix+.anywhere@down">tool.attr gen.helix sides ?-</hash>
+		<hash type="Region" key="view3DTools+toolPreset.gen.helix+.anywhere@d">tool.attr gen.helix sides ?+</hash>
+		<hash type="Region" key="view3DTools+toolPreset.gen.helix+.anywhere@a">tool.attr gen.helix sides ?-</hash>
+		<hash type="Region" key="view3DTools+toolPreset.gen.helix+.anywhere@mouse5">tool.attr gen.helix sides ?+</hash>
+		<hash type="Region" key="view3DTools+toolPreset.gen.helix+.anywhere@mouse4">tool.attr gen.helix sides ?-</hash>
+		
+		<!-- use z key to loop axises instead of useing x,y,z three keys-->
+		<hash type="Region" key="view3DTools+toolPreset.gen.helix+.anywhere@z">tool.attr gen.helix axis ?(0|1|2)</hash>
+		<!-- 
+		<hash type="Region" key="view3DTools+toolPreset.gen.helix+.anywhere@x">tool.attr gen.helix axis 0</hash>
+		<hash type="Region" key="view3DTools+toolPreset.gen.helix+.anywhere@y">tool.attr gen.helix axis 1</hash>
+		<hash type="Region" key="view3DTools+toolPreset.gen.helix+.anywhere@z">tool.attr gen.helix axis 2</hash>
+		-->
+	<!-- -->
+	
+	<!-- Edge Slice -->
+		<hash type="Region" key="view3DTools+toolPreset.edge.knife+.anywhere@m">tool.attr edge.knife multi ?+</hash>
+	<!-- -->
+	
+	<!-- Slice(Poly Knife) -->
+		<hash type="Region" key="view3DTools+toolPreset.poly.knife+.anywhere@s">tool.attr poly.knife split ?+</hash>
+		<hash type="Region" key="view3DTools+toolPreset.poly.knife+.anywhere@c">tool.attr poly.knife caps ?+</hash>
+		<hash type="Region" key="view3DTools+toolPreset.poly.knife+.anywhere@i">tool.attr poly.knife infinite ?+</hash>
+		<hash type="Region" key="view3DTools+toolPreset.poly.knife+.anywhere@z">tool.attr poly.knife axis ?+</hash>
+	<!-- -->
+	
+	<!-- Loop Slice -->
+		<hash type="Region" key="view3DTools+toolPreset.poly.loopSlice+.anywhere@up">tool.attr poly.loopSlice count ?+</hash>
+		<hash type="Region" key="view3DTools+toolPreset.poly.loopSlice+.anywhere@down">tool.attr poly.loopSlice count ?-</hash>
+		<hash type="Region" key="view3DTools+toolPreset.poly.loopSlice+.anywhere@d">tool.attr poly.loopSlice count ?+</hash>
+		<hash type="Region" key="view3DTools+toolPreset.poly.loopSlice+.anywhere@a">tool.attr poly.loopSlice count ?-</hash>
+		<hash type="Region" key="view3DTools+toolPreset.poly.loopSlice+.anywhere@mouse5">tool.attr poly.loopSlice count ?+</hash>
+		<hash type="Region" key="view3DTools+toolPreset.poly.loopSlice+.anywhere@mouse4">tool.attr poly.loopSlice count ?-</hash>
+		<hash type="Region" key="view3DTools+toolPreset.poly.loopSlice+.anywhere@right">tool.attr poly.loopSlice curr ?+</hash>
+		<hash type="Region" key="view3DTools+toolPreset.poly.loopSlice+.anywhere@left">tool.attr poly.loopSlice curr ?-</hash>
+		<hash type="Region" key="view3DTools+toolPreset.poly.loopSlice+.anywhere@shift-mouse5">tool.attr poly.loopSlice curr ?+</hash>
+		<hash type="Region" key="view3DTools+toolPreset.poly.loopSlice+.anywhere@shift-d">tool.attr poly.loopSlice curr ?+</hash>
+		<hash type="Region" key="view3DTools+toolPreset.poly.loopSlice+.anywhere@shift-a">tool.attr poly.loopSlice curr ?-</hash>
+		<hash type="Region" key="view3DTools+toolPreset.poly.loopSlice+.anywhere@shift-mouse4">tool.attr poly.loopSlice curr ?-</hash>
+		<hash type="Region" key="view3DTools+toolPreset.poly.loopSlice+.anywhere@.">tool.attr poly.loopSlice curr ?+</hash>
+		<hash type="Region" key="view3DTools+toolPreset.poly.loopSlice+.anywhere@,">tool.attr poly.loopSlice curr ?-</hash>
+		<hash type="Region" key="view3DTools+toolPreset.poly.loopSlice+.anywhere@p">tool.attr poly.loopSlice curvature ?+</hash>
+	<!-- -->
+	
+	<!-- CURVE SLICE -->
+		<hash type="Region" key="view3DTools+toolPreset.gen.pathsteps+.anywhere@up">tool.attr gen.pathsteps number ?+</hash>
+		<hash type="Region" key="view3DTools+toolPreset.gen.pathsteps+.anywhere@down">tool.attr gen.pathsteps number ?-</hash>
+		<hash type="Region" key="view3DTools+toolPreset.gen.pathsteps+.anywhere@d">tool.attr gen.pathsteps number ?+</hash>
+		<hash type="Region" key="view3DTools+toolPreset.gen.pathsteps+.anywhere@a">tool.attr gen.pathsteps number ?-</hash>
+		<hash type="Region" key="view3DTools+toolPreset.gen.pathsteps+.anywhere@mouse5">tool.attr gen.pathsteps number ?+</hash>
+		<hash type="Region" key="view3DTools+toolPreset.gen.pathsteps+.anywhere@mouse4">tool.attr gen.pathsteps number ?-</hash>
+	<!--  -->
+	
+	<!-- ADD LOOP -->
+		<hash type="Region" key="view3DTools+toolPreset.edge.addLoop+.anywhere@b">tool.attr edge.addLoop bothSides ?+</hash>
+		<hash type="Region" key="view3DTools+toolPreset.edge.addLoop+.anywhere@c">tool.attr edge.addLoop absDistance ?+</hash>
+		<hash type="Region" key="view3DTools+toolPreset.edge.addLoop+.anywhere@m">tool.attr edge.addLoop middle ?+</hash>
+		<hash type="Region" key="view3DTools+toolPreset.edge.addLoop+.anywhere@f">tool.attr edge.addLoop absFromEnd ?+</hash>
+		<hash type="Region" key="view3DTools+toolPreset.edge.addLoop+.anywhere@p">tool.attr edge.addLoop curvature ?+</hash>
+	<!--  -->
+	
+	<!-- ADD POINT -->
+		<hash type="Region" key="view3DTools+toolPreset.edge.addPoint+.anywhere@m">tool.attr edge.addPoint middle ?+</hash>
+		<hash type="Region" key="view3DTools+toolPreset.edge.addPoint+.anywhere@p">tool.attr edge.addPoint curvature ?+</hash>
+	<!--  -->
+	
+	<!-- EDGE SLIDE -->
+		<hash type="Region" key="view3DTools+toolPreset.edge.slide+.anywhere@c">tool.attr edge.slide duplicate ?+</hash>
+		<hash type="Region" key="view3DTools+toolPreset.edge.slide+.anywhere@d">tool.attr edge.slide segs ?+</hash>
+		<hash type="Region" key="view3DTools+toolPreset.edge.slide+.anywhere@a">tool.attr edge.slide segs ?-</hash>
+		<hash type="Region" key="view3DTools+toolPreset.edge.slide+.anywhere@mouse5">tool.attr edge.slide segs ?+</hash>
+		<hash type="Region" key="view3DTools+toolPreset.edge.slide+.anywhere@mouse4">tool.attr edge.slide segs ?-</hash>
+	<!--  -->
+	
+	<!-- POLYGON EXTRUDE -->
+		<hash type="Region" key="view3DTools+toolPreset.poly.extrude+.anywhere@up">tool.attr poly.extrude segs ?+</hash>
+		<hash type="Region" key="view3DTools+toolPreset.poly.extrude+.anywhere@down">tool.attr poly.extrude segs ?-</hash>
+		<hash type="Region" key="view3DTools+toolPreset.poly.extrude+.anywhere@d">tool.attr poly.extrude segs ?+</hash>
+		<hash type="Region" key="view3DTools+toolPreset.poly.extrude+.anywhere@a">tool.attr poly.extrude segs ?-</hash>
+		<hash type="Region" key="view3DTools+toolPreset.poly.extrude+.anywhere@mouse5">tool.attr poly.extrude segs ?+</hash>
+		<hash type="Region" key="view3DTools+toolPreset.poly.extrude+.anywhere@mouse4">tool.attr poly.extrude segs ?-</hash>
+	<!--  -->
+	
+	<!-- EDGE EXTEND -->
+		<hash type="Region" key="view3DTools+toolPreset.edge.extend+.anywhere@up">tool.attr edge.extend segs ?+</hash>
+		<hash type="Region" key="view3DTools+toolPreset.edge.extend+.anywhere@down">tool.attr edge.extend segs ?-</hash>
+		<hash type="Region" key="view3DTools+toolPreset.edge.extend+.anywhere@d">tool.attr edge.extend segs ?+</hash>
+		<hash type="Region" key="view3DTools+toolPreset.edge.extend+.anywhere@a">tool.attr edge.extend segs ?-</hash>
+		<hash type="Region" key="view3DTools+toolPreset.edge.extend+.anywhere@mouse5">tool.attr edge.extend segs ?+</hash>
+		<hash type="Region" key="view3DTools+toolPreset.edge.extend+.anywhere@mouse4">tool.attr edge.extend segs ?-</hash>
+	<!--  -->
+	
+	<!-- BRIDGE -->
+		<hash type="Region" key="view3DTools+toolPreset.edge.bridge+.anywhere@up">tool.attr edge.bridge segments ?+</hash>
+		<hash type="Region" key="view3DTools+toolPreset.edge.bridge+.anywhere@down">tool.attr edge.bridge segments ?-</hash>
+		<hash type="Region" key="view3DTools+toolPreset.edge.bridge+.anywhere@d">tool.attr edge.bridge segments ?+</hash>
+		<hash type="Region" key="view3DTools+toolPreset.edge.bridge+.anywhere@a">tool.attr edge.bridge segments ?-</hash>
+		<hash type="Region" key="view3DTools+toolPreset.edge.bridge+.anywhere@mouse5">tool.attr edge.bridge segments ?+</hash>
+		<hash type="Region" key="view3DTools+toolPreset.edge.bridge+.anywhere@mouse4">tool.attr edge.bridge segments ?-</hash>
+		<hash type="Region" key="view3DTools+toolPreset.edge.bridge+.anywhere@r">tool.attr edge.bridge remove ?+</hash>
+	<!--  -->
+	
+	<!-- CUBE -->
+		<hash type="Region" key="view3DTools+toolPreset.prim.cube+.anywhere@x">tool.attr prim.cube segmentsX ?+</hash>
+		<hash type="Region" key="view3DTools+toolPreset.prim.cube+.anywhere@shift-x">tool.attr prim.cube segmentsX ?-</hash>
+		<hash type="Region" key="view3DTools+toolPreset.prim.cube+.anywhere@y">tool.attr prim.cube segmentsY ?+</hash>
+		<hash type="Region" key="view3DTools+toolPreset.prim.cube+.anywhere@shift-y">tool.attr prim.cube segmentsY ?-</hash>
+		<hash type="Region" key="view3DTools+toolPreset.prim.cube+.anywhere@z">tool.attr prim.cube segmentsZ ?+</hash>
+		<hash type="Region" key="view3DTools+toolPreset.prim.cube+.anywhere@shift-z">tool.attr prim.cube segmentsZ ?-</hash>
+	<!--  -->
+	
+	<!-- SPHERE -->
+		<hash type="Region" key="view3DTools+toolPreset.prim.sphere+.anywhere@up">tool.attr prim.sphere sides ?+</hash>
+		<hash type="Region" key="view3DTools+toolPreset.prim.sphere+.anywhere@down">tool.attr prim.sphere sides ?-</hash>
+		<hash type="Region" key="view3DTools+toolPreset.prim.sphere+.anywhere@shift-up">tool.attr prim.sphere segments ?+</hash>
+		<hash type="Region" key="view3DTools+toolPreset.prim.sphere+.anywhere@shift-down">tool.attr prim.sphere segments ?-</hash>
+		<hash type="Region" key="view3DTools+toolPreset.prim.sphere+.anywhere@d">tool.attr prim.sphere sides ?+</hash>
+		<hash type="Region" key="view3DTools+toolPreset.prim.sphere+.anywhere@a">tool.attr prim.sphere sides ?-</hash>
+		<hash type="Region" key="view3DTools+toolPreset.prim.sphere+.anywhere@mouse5">tool.attr prim.sphere sides ?+</hash>
+		<hash type="Region" key="view3DTools+toolPreset.prim.sphere+.anywhere@mouse4">tool.attr prim.sphere sides ?-</hash>
+		<hash type="Region" key="view3DTools+toolPreset.prim.sphere+.anywhere@shift-w">tool.attr prim.sphere segments ?+</hash>
+		<hash type="Region" key="view3DTools+toolPreset.prim.sphere+.anywhere@shift-q">tool.attr prim.sphere segments ?-</hash>
+		<hash type="Region" key="view3DTools+toolPreset.prim.sphere+.anywhere@shift-mouse5">tool.attr prim.sphere segments ?+</hash>
+		<hash type="Region" key="view3DTools+toolPreset.prim.sphere+.anywhere@shift-mouse4">tool.attr prim.sphere segments ?-</hash>
+		<hash type="Region" key="view3DTools+toolPreset.prim.sphere+.anywhere@z">tool.attr prim.sphere axis ?(0|1|2)</hash>
+		<!--
+		<hash type="Region" key="view3DTools+toolPreset.prim.sphere+.anywhere@x">tool.attr prim.sphere axis 0</hash>
+		<hash type="Region" key="view3DTools+toolPreset.prim.sphere+.anywhere@y">tool.attr prim.sphere axis 1</hash>
+		<hash type="Region" key="view3DTools+toolPreset.prim.sphere+.anywhere@z">tool.attr prim.sphere axis 2</hash>
+		-->
+	<!--  -->
+	
+	<!-- CYLINDER -->
+		<hash type="Region" key="view3DTools+toolPreset.prim.cylinder+.anywhere@right">tool.attr prim.cylinder sides ?+</hash>
+		<hash type="Region" key="view3DTools+toolPreset.prim.cylinder+.anywhere@left">tool.attr prim.cylinder sides ?-</hash>
+		<hash type="Region" key="view3DTools+toolPreset.prim.cylinder+.anywhere@up">tool.attr prim.cylinder segments ?+</hash>
+		<hash type="Region" key="view3DTools+toolPreset.prim.cylinder+.anywhere@down">tool.attr prim.cylinder segments ?-</hash>
+		<hash type="Region" key="view3DTools+toolPreset.prim.cylinder+.anywhere@d">tool.attr prim.cylinder sides ?+</hash>
+		<hash type="Region" key="view3DTools+toolPreset.prim.cylinder+.anywhere@a">tool.attr prim.cylinder sides ?-</hash>
+		<hash type="Region" key="view3DTools+toolPreset.prim.cylinder+.anywhere@mouse5">tool.attr prim.cylinder sides ?+</hash>
+		<hash type="Region" key="view3DTools+toolPreset.prim.cylinder+.anywhere@mouse4">tool.attr prim.cylinder sides ?-</hash>
+		<hash type="Region" key="view3DTools+toolPreset.prim.cylinder+.anywhere@shift-w">tool.attr prim.cylinder segments ?+</hash>
+		<hash type="Region" key="view3DTools+toolPreset.prim.cylinder+.anywhere@shift-q">tool.attr prim.cylinder segments ?-</hash>
+		<hash type="Region" key="view3DTools+toolPreset.prim.cylinder+.anywhere@z">tool.attr prim.cylinder axis ?(0|1|2)</hash>
+		<!--  
+		<hash type="Region" key="view3DTools+toolPreset.prim.cylinder+.anywhere@x">tool.attr prim.cylinder axis 0</hash>
+		<hash type="Region" key="view3DTools+toolPreset.prim.cylinder+.anywhere@y">tool.attr prim.cylinder axis 1</hash>
+		<hash type="Region" key="view3DTools+toolPreset.prim.cylinder+.anywhere@z">tool.attr prim.cylinder axis 2</hash>
+		-->
+	<!--  -->
+	
+	<!-- TUBE -->
+		<hash type="Region" key="view3DTools+toolPreset.prim.tube+.anywhere@up">tool.attr prim.tube sides ?+</hash>
+		<hash type="Region" key="view3DTools+toolPreset.prim.tube+.anywhere@down">tool.attr prim.tube sides ?-</hash>
+		<hash type="Region" key="view3DTools+toolPreset.prim.tube+.anywhere@right">tool.attr prim.tube segments ?+</hash>
+		<hash type="Region" key="view3DTools+toolPreset.prim.tube+.anywhere@left">tool.attr prim.tube segments ?-</hash>
+		<hash type="Region" key="view3DTools+toolPreset.prim.tube+.anywhere@d">tool.attr prim.tube sides ?+</hash>
+		<hash type="Region" key="view3DTools+toolPreset.prim.tube+.anywhere@a">tool.attr prim.tube sides ?-</hash>
+		<hash type="Region" key="view3DTools+toolPreset.prim.tube+.anywhere@mouse5">tool.attr prim.tube sides ?+</hash>
+		<hash type="Region" key="view3DTools+toolPreset.prim.tube+.anywhere@mouse4">tool.attr prim.tube sides ?-</hash>
+		<hash type="Region" key="view3DTools+toolPreset.prim.tube+.anywhere@shift-w">tool.attr prim.tube segments ?+</hash>
+		<hash type="Region" key="view3DTools+toolPreset.prim.tube+.anywhere@shift-q">tool.attr prim.tube segments ?-</hash>
+		<hash type="Region" key="view3DTools+toolPreset.prim.tube+.anywhere@shift-mouse5">tool.attr prim.tube segments ?+</hash>
+		<hash type="Region" key="view3DTools+toolPreset.prim.tube+.anywhere@shift-mouse4">tool.attr prim.tube segments ?-</hash>
+		<hash type="Region" key="view3DTools+toolPreset.prim.tube+.anywhere@r">tool.attr prim.tube radius ?+.01</hash>
+		<hash type="Region" key="view3DTools+toolPreset.prim.tube+.anywhere@shift-r">tool.attr prim.tube radius ?-.01</hash>
+		<hash type="Region" key="view3DTools+toolPreset.prim.tube+.anywhere@c">tool.attr prim.tube caps ?+</hash>
+		<hash type="Region" key="view3DTools+toolPreset.prim.tube+.anywhere@l">tool.attr prim.tube length ?+</hash>
+	<!--  -->
+	
+	<!-- CONE -->
+		<hash type="Region" key="view3DTools+toolPreset.prim.cone+.anywhere@up">tool.attr prim.cone sides ?+</hash>
+		<hash type="Region" key="view3DTools+toolPreset.prim.cone+.anywhere@down">tool.attr prim.cone sides ?-</hash>
+		<hash type="Region" key="view3DTools+toolPreset.prim.cone+.anywhere@right">tool.attr prim.cone segments ?+</hash>
+		<hash type="Region" key="view3DTools+toolPreset.prim.cone+.anywhere@left">tool.attr prim.cone segments ?-</hash>
+		<hash type="Region" key="view3DTools+toolPreset.prim.cone+.anywhere@d">tool.attr prim.cone sides ?+</hash>
+		<hash type="Region" key="view3DTools+toolPreset.prim.cone+.anywhere@a">tool.attr prim.cone sides ?-</hash>
+		<hash type="Region" key="view3DTools+toolPreset.prim.cone+.anywhere@mouse5">tool.attr prim.cone sides ?+</hash>
+		<hash type="Region" key="view3DTools+toolPreset.prim.cone+.anywhere@mouse4">tool.attr prim.cone sides ?-</hash>
+		<hash type="Region" key="view3DTools+toolPreset.prim.cone+.anywhere@shift-w">tool.attr prim.cone segments ?+</hash>
+		<hash type="Region" key="view3DTools+toolPreset.prim.cone+.anywhere@shift-q">tool.attr prim.cone segments ?-</hash>
+		<hash type="Region" key="view3DTools+toolPreset.prim.cone+.anywhere@shift-mouse5">tool.attr prim.cone segments ?+</hash>
+		<hash type="Region" key="view3DTools+toolPreset.prim.cone+.anywhere@shift-mouse4">tool.attr prim.cone segments ?-</hash>
+		<hash type="Region" key="view3DTools+toolPreset.prim.cone+.anywhere@z">tool.attr prim.cone axis ?(0|1|2)</hash>
+		<!--  
+		<hash type="Region" key="view3DTools+toolPreset.prim.cone+.anywhere@x">tool.attr prim.cone axis 0</hash>
+		<hash type="Region" key="view3DTools+toolPreset.prim.cone+.anywhere@y">tool.attr prim.cone axis 1</hash>
+		<hash type="Region" key="view3DTools+toolPreset.prim.cone+.anywhere@z">tool.attr prim.cone axis 2</hash>
+		-->
+	<!--  -->
+	
+	<!-- TOROID -->
+		<hash type="Region" key="view3DTools+toolPreset.prim.toroid+.anywhere@up">tool.attr prim.toroid sides ?+</hash>
+		<hash type="Region" key="view3DTools+toolPreset.prim.toroid+.anywhere@down">tool.attr prim.toroid sides ?-</hash>
+		<hash type="Region" key="view3DTools+toolPreset.prim.toroid+.anywhere@right">tool.attr prim.toroid segments ?+</hash>
+		<hash type="Region" key="view3DTools+toolPreset.prim.toroid+.anywhere@left">tool.attr prim.toroid segments ?-</hash>
+		<hash type="Region" key="view3DTools+toolPreset.prim.toroid+.anywhere@d">tool.attr prim.toroid sides ?+</hash>
+		<hash type="Region" key="view3DTools+toolPreset.prim.toroid+.anywhere@a">tool.attr prim.toroid sides ?-</hash>
+		<hash type="Region" key="view3DTools+toolPreset.prim.toroid+.anywhere@mouse5">tool.attr prim.toroid sides ?+</hash>
+		<hash type="Region" key="view3DTools+toolPreset.prim.toroid+.anywhere@mouse4">tool.attr prim.toroid sides ?-</hash>
+		<hash type="Region" key="view3DTools+toolPreset.prim.toroid+.anywhere@shift-w">tool.attr prim.toroid segments ?+</hash>
+		<hash type="Region" key="view3DTools+toolPreset.prim.toroid+.anywhere@shift-q">tool.attr prim.toroid segments ?-</hash>
+		<hash type="Region" key="view3DTools+toolPreset.prim.toroid+.anywhere@shift-mouse5">tool.attr prim.toroid segments ?+</hash>
+		<hash type="Region" key="view3DTools+toolPreset.prim.toroid+.anywhere@shift-mouse4">tool.attr prim.toroid segments ?-</hash>
+		<hash type="Region" key="view3DTools+toolPreset.prim.toroid+.anywhere@z">tool.attr prim.toroid axis ?(0|1|2)</hash>
+		<!--  
+		<hash type="Region" key="view3DTools+toolPreset.prim.toroid+.anywhere@x">tool.attr prim.toroid axis 0</hash>
+		<hash type="Region" key="view3DTools+toolPreset.prim.toroid+.anywhere@y">tool.attr prim.toroid axis 1</hash>
+		<hash type="Region" key="view3DTools+toolPreset.prim.toroid+.anywhere@z">tool.attr prim.toroid axis 2</hash>
+		-->
+	<!--  -->
+	
+	<!-- Linear Falloff -->
+		<hash type="Region" key="view3DTools+toolPreset.falloff.linear+.anywhere@r">falloff.reverse</hash>
+		<hash type="Region" key="view3DTools+toolPreset.falloff.linear+.anywhere@s">tool.attr falloff.linear symmetric ?+</hash>
+		<hash type="Region" key="view3DTools+toolPreset.falloff.linear+.anywhere@p">tool.attr falloff.linear shape ?+</hash>		
+		<hash type="Region" key="view3DTools+toolPreset.falloff.linear+.anywhere@x">falloff.axisAutoSize 0</hash>
+		<hash type="Region" key="view3DTools+toolPreset.falloff.linear+.anywhere@y">falloff.axisAutoSize 1</hash>
+		<hash type="Region" key="view3DTools+toolPreset.falloff.linear+.anywhere@z">falloff.axisAutoSize 2</hash>
+	<!-- -->
+	
+	<!-- Selection Falloff -->
+		<hash type="Region" key="view3DTools+toolPreset.falloff.selection+.anywhere@d">tool.attr falloff.selection steps ?+</hash>
+		<hash type="Region" key="view3DTools+toolPreset.falloff.selection+.anywhere@a">tool.attr falloff.selection steps ?-</hash>
+		<hash type="Region" key="view3DTools+toolPreset.falloff.selection+.anywhere@mouse5">falloff.selection steps ?+</hash>
+		<hash type="Region" key="view3DTools+toolPreset.falloff.selection+.anywhere@mouse4">falloff.selection steps ?-</hash>
+		<hash type="Region" key="view3DTools+toolPreset.falloff.selection+.anywhere@s">tool.attr falloff.selection shape ?(0|1|2|3|4)</hash>		
+	<!-- -->
+	
+	<!-- Soft Selection Falloff -->
+		<hash type="Region" key="view3DTools+toolPreset.falloff.softSelection+.anywhere@s">tool.attr falloff.selection shape ?(0|1|2|3|4)</hash>		
+	<!-- -->
+	
+	<!-- SCALE TOOL -->
+		<hash type="Region" key="view3DTools+toolPreset.TransformScale+.anywhere@n">tool.attr xfrm.transform negScale ?+</hash>
+		<hash type="Region" key="view3DTools+toolPreset.TransformScale+.anywhere@u">tool.attr xfrm.transform lockUV ?+</hash>
+		
+		<hash type="Region" key="view3DTools+toolPreset.TransformScale+.anywhere@ctrl-alt-x">tool.setAttr xfrm.transform SX 0.0</hash>
+		<hash type="Region" key="view3DTools+toolPreset.TransformScale+.anywhere@y">tool.setAttr xfrm.transform SY 0.0</hash>
+		<hash type="Region" key="view3DTools+toolPreset.TransformScale+.anywhere@ctrl-alt-z">tool.setAttr xfrm.transform SZ 0.0</hash>
+		
+		<hash type="Region" key="view3DTools+toolPreset.TransformScale+.anywhere@t">tool.xfrmDisco ?+</hash>
+	<!--  -->
+	
+	<!-- ########## -->
+	<!-- Global hot keys -->
+	<!-- ########## -->
+	
+	<!-- LEFT MOUSE BUTTON -->
+		<hash type="Region" key="view3DTools+(contextless)/(stateless)+.anywhere@ctrl-shift-lmb">@lazySelect.pl selectByPoly</hash>
+		<hash type="Region" key="view3DTools+(contextless)/(stateless)+.anywhere@alt-lmb">@selectThatMesh.pl</hash>
+	<!--  -->
+	
+	<!-- Merge Vertices -->
+		<hash type="Region" key=".global+(contextless)/(stateless)+.anywhere@alt-m">vert.merge auto false 0.001 false true</hash>
+	<!--  -->
+	
+	<!-- Item Properties popvoer -->
+		<hash type="Region" key=".global+(contextless)/(stateless)+.anywhere@alt-p">attr.formPopover {itemprops:general}</hash>
+	<!--  -->
+	
+	<!-- Universal3dmenu -->
+		<hash type="Region" key=".global+(contextless)/(stateless)+.anywhere@space">attr.formPopover {36715731631:sheet}</hash>
+	<!--  -->
+	
+	<!-- Modeling Operation Pie menu -->
+		<hash type="Region" key=".global+(contextless)/(stateless)+.anywhere@shift-space">attr.formPopover {09376494926:sheet}</hash>
+	<!--  -->
+	
+	<!-- Action Center Pie -->
+		<hash type="Region" key=".global+(contextless)/(stateless)+.anywhere@alt-a">attr.formPopover {18184886527:sheet}</hash>
+	<!--  -->
+	
+	<!-- Falloff Pie -->
+		<hash type="Region" key="view3DNavigate+(contextless)/(stateless)+.anywhere@shift-f">attr.formPopover {96296886562:sheet}</hash>
+	<!--  -->
+	
+	<!-- ETEREA's Super Aligner pie -->
+		<hash type="Region" key=".global+(contextless)/(stateless)+.anywhere@ctrl-f">attr.formPopover {29517870907:sheet}</hash>
+	<!--  -->
+	
+	<!-- ETEREA's Slice Presets pie -->
+		<hash type="Region" key=".global+(contextless)/(stateless)+.anywhere@ctrl-alt-c">attr.formPopover {65836340310:sheet}</hash>
+	<!--  -->
+	
+	<!-- ETEREA Primitives -->
+		<hash type="Region" key=".global+(contextless)/(stateless)+.anywhere@alt-n">attr.formPopover {79312484437:sheet}</hash>
+	<!--  -->
+	
+	<!-- ETEREA Falloff Pie -->
+		<hash type="Region" key=".global+(contextless)/(stateless)+.anywhere@ctrl-alt-f">attr.formPopover {98296715196:sheet}</hash>
+	<!--  -->
+	
+	<!-- Sen's Random Selector -->
+		<hash type="Region" key=".global+(contextless)/(stateless)+.anywhere@alt-s">attr.formPopover {17680715101:sheet}</hash>
+	<!--  -->
+	
+	<!-- Selection Set Pie -->
+		<hash type="Region" key=".global+(contextless)/(stateless)+.anywhere@alt-w">attr.formPopover {74633695160:sheet}</hash>
+	<!--  -->
+	
+	<!-- Instance Operation Pie -->
+		<hash type="Region" key=".global+(contextless)/(stateless)+.anywhere@ctrl-alt-d">attr.formPopover {15591781406:sheet}</hash>
+	<!--  -->
+	
+	<!-- Duplicate Operation Pie -->
+		<hash type="Region" key=".global+(contextless)/(stateless)+.anywhere@alt-d">attr.formPopover {13945780621:sheet}</hash>
+	<!--  -->
+	
+	<!-- Viewports Pie -->
+		<hash type="Region" key=".global+(contextless)/(stateless)+.anywhere@alt-h">attr.formPopover {67300786789:sheet}</hash>
+	<!--  -->
+	
+	<!-- mARCH palette -->
+		<hash type="Region" key=".global+(contextless)/(stateless)+.anywhere@ctrl-m">attr.formPopover {mARCH.01.72217924097:sheet}</hash>
+	<!--  -->
+	  </atom>
+</configuration>

--- a/Configs/GooseBig's Macros.CFG
+++ b/Configs/GooseBig's Macros.CFG
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+  <atom type="Macros">
+    <hash type="Macro" key="41442889182:macro">
+      <atom type="UserName">g_Bridge_WithoutPop</atom>
+      <list type="Command">   tool.set edge.bridge on</list>
+      <list type="Command">   tool.apply</list>
+      <list type="Command">   tool.drop</list>
+    </hash>
+    <hash type="Macro" key="13065889212:macro">
+      <atom type="UserName">g_JoinAverage_WithoutPop</atom>
+      <list type="Command">   vert.join true</list>
+    </hash>
+    <hash type="Macro" key="73283889237:macro">
+      <atom type="UserName">g_Join_WithoutPop</atom>
+      <list type="Command">   vert.join false false</list>
+    </hash>
+    <hash type="Macro" key="60009889262:macro">
+      <atom type="UserName">g_MergeVertices_WithoutPop</atom>
+      <list type="Command">   vert.merge auto false 0.001 false true</list>
+    </hash>
+    <hash type="Macro" key="41052140685:macro">
+      <atom type="UserName">g_Mirror X</atom>
+      <atom type="Desc">center 0 0 0</atom>
+      <list type="Command">tool.set *.mirror on</list>
+      <list type="Command">tool.attr gen.mirror axis 0</list>
+      <list type="Command">tool.apply</list>
+    </hash>
+    <hash type="Macro" key="77813140735:macro">
+      <atom type="UserName">g_Mirror Y</atom>
+      <atom type="Desc">center 0 0 0</atom>
+      <list type="Command">tool.set *.mirror on</list>
+      <list type="Command">tool.attr gen.mirror axis 1</list>
+      <list type="Command">tool.apply</list>
+    </hash>
+    <hash type="Macro" key="95758140782:macro">
+      <atom type="UserName">g_Mirror Z</atom>
+      <atom type="Desc">center 0 0 0</atom>
+      <list type="Command">tool.set *.mirror on</list>
+      <list type="Command">tool.attr gen.mirror axis 2</list>
+      <list type="Command">tool.apply</list>
+    </hash>
+    <hash type="Macro" key="07409144301:macro">
+      <atom type="UserName">g_ItemAlign2WPOrigion</atom>
+      <atom type="Desc">Align Item to Workplane Position and Rotation</atom>
+      <list type="Command">matchWorkplaneRot</list>
+      <list type="Command">matchWorkplanePos</list>
+      <list type="Command"></list>
+    </hash>
+	<hash type="Macro" key="50734388182:macro">
+      <atom type="UserName">g_MakeItOneCirclePoly</atom>
+	  <atom type="Desc">Turn selected polygons into One Circle Polygon</atom>
+      <list type="Command">@perfectCircle.pl</list>
+      <list type="Command">script.run "macro.scriptservice:92663570022:macro"</list>
+      <list type="Command">select.typeFrom polygon;edge;vertex;item;pivot;center;ptag true</list>
+      <list type="Command">delete</list>
+      <list type="Command">select.typeFrom edge;vertex;polygon;item;pivot;center;ptag true</list>
+      <list type="Command">poly.make auto</list>
+      <list type="Command">select.typeFrom polygon;edge;vertex;item;pivot;center;ptag true</list>
+      <list type="Command"></list>
+    </hash>
+  </atom>
+</configuration>

--- a/Configs/GooseBig's Modeling Operation Pie.CFG
+++ b/Configs/GooseBig's Modeling Operation Pie.CFG
@@ -1,0 +1,130 @@
+<?xml version="1.0"?>
+<configuration>
+  <atom type="Attributes">
+    <hash type="Sheet" key="09376494926:sheet">
+      <atom type="Label">Modeling Operations Pie</atom>
+      <atom type="Desc">Hotkey = shift-space (registered in GooseBig's InputRemapping.CFG)</atom>
+      <atom type="Style">pie</atom>
+      <atom type="EditorColor">786432</atom>
+      <atom type="Group">piemenus</atom>
+      <list type="Control" val="cmd @&quot;g_Join_WithoutPop&quot;">
+        <atom type="Label">Join w/o</atom>
+      </list>
+      <list type="Control" val="cmd @g_JoinAverage_WithoutPop">
+        <atom type="Label">JoinAverage w/o</atom>
+      </list>
+      <list type="Control" val="cmd @g_Bridge_WithoutPop">
+        <atom type="Label">Bridge w/o</atom>
+      </list>
+      <list type="Control" val="cmd @g_MergeVertices_WithoutPop">
+        <atom type="Label">Merge Vertices w/o</atom>
+      </list>
+      <list type="Control" val="cmd @quickPipe.pl">
+        <atom type="Label">QuickPipe</atom>
+      </list>
+      <list type="Control" val="sub 30931811656:sheet">
+        <atom type="Label">Quick Tools...</atom>
+        <atom type="Style">pie</atom>
+        <atom type="Hash">30931811656:sheet</atom>
+      </list>
+      <list type="Control" val="sub 02813786770:sheet">
+        <atom type="Label">Lasso Settings...</atom>
+        <atom type="Style">pie</atom>
+        <atom type="Hash">02813786770:sheet</atom>
+      </list>
+      <list type="Control" val="sub 36669673464:sheet">
+        <atom type="Label">Center Selected...</atom>
+        <atom type="Style">pie</atom>
+        <atom type="Hash">36669673464:sheet</atom>
+      </list>
+    </hash>
+    <hash type="Sheet" key="30931811656:sheet">
+      <atom type="Label">Quick Tools...</atom>
+      <atom type="Style">pie</atom>
+      <list type="Control" val="cmd @&quot;g_Mirror Y&quot;">
+        <atom type="Label">Mirror Y w/o</atom>
+      </list>
+      <list type="Control" val="cmd @&quot;g_Mirror Z&quot;">
+        <atom type="Label">Mirror Z w/o</atom>
+      </list>
+      <list type="Control" val="cmd @&quot;g_Mirror X&quot;">
+        <atom type="Label">Mirror X w/o</atom>
+      </list>
+      <list type="Control" val="cmd tool.set DragWeld on snap:true">
+        <atom type="Label">Drag Weld</atom>
+      </list>
+      <list type="Control" val="cmd @&quot;g_ItemAlign2WPOrigion&quot;">
+        <atom type="Label">Item Align to WP Origion</atom>
+      </list>
+      <list type="Control" val="cmd tool.set sculpt.vmapSetVal on rawquery:true">
+        <atom type="Label">VMapSetValue</atom>
+      </list>
+      <list type="Control" val="cmd @g_MakeItOneCirclePoly">
+        <atom type="Label">Circle Polygon</atom>
+      </list>
+      <list type="Control" val="cmd tool.set xfrm.radialAlign on">
+        <atom type="Label">Radial Align</atom>
+      </list>
+      <list type="Control" val="cmd tool.set sculpt.vmapPaint on rawquery:true">
+        <atom type="Label">VMapPaint</atom>
+      </list>
+    </hash>
+    <hash type="Sheet" key="02813786770:sheet">
+      <atom type="Label">Lasso Settings...</atom>
+      <atom type="Style">pie</atom>
+      <list type="Control" val="cmd pref.value remapping.lassoSelectPartial true">
+        <atom type="Label">LassoSelectPartial On</atom>
+      </list>
+      <list type="Control" val="div ">
+        <atom type="Alignment">full</atom>
+        <atom type="Hash">59147786799:control</atom>
+      </list>
+      <list type="Control" val="cmd select.lassoStyle rectangle">
+        <atom type="Label">LassoStyle Rectangle</atom>
+      </list>
+      <list type="Control" val="div ">
+        <atom type="Alignment">full</atom>
+        <atom type="Hash">01731786810:control</atom>
+      </list>
+      <list type="Control" val="cmd pref.value remapping.lassoSelectPartial false">
+        <atom type="Label">LassoSelectPartial Off</atom>
+      </list>
+      <list type="Control" val="div ">
+        <atom type="Alignment">full</atom>
+        <atom type="Hash">89111786813:control</atom>
+      </list>
+      <list type="Control" val="cmd select.lassoStyle lasso">
+        <atom type="Label">LassoStyle Lasso</atom>
+      </list>
+    </hash>
+    <hash type="Sheet" key="36669673464:sheet">
+      <atom type="Label">Center Selected...</atom>
+      <atom type="Style">pie</atom>
+      <list type="Control" val="cmd vert.center y">
+        <atom type="Label">Y</atom>
+      </list>
+      <list type="Control" val="cmd vert.center xy">
+        <atom type="Label">XY</atom>
+      </list>
+      <list type="Control" val="cmd vert.center x">
+        <atom type="Label">X</atom>
+      </list>
+      <list type="Control" val="cmd vert.center all">
+        <atom type="Label">All</atom>
+      </list>
+      <list type="Control" val="cmd vert.center zx">
+        <atom type="Label">ZX</atom>
+      </list>
+      <list type="Control" val="div ">
+        <atom type="Alignment">full</atom>
+        <atom type="Hash">03221380332:control</atom>
+      </list>
+      <list type="Control" val="cmd vert.center z">
+        <atom type="Label">Z</atom>
+      </list>
+      <list type="Control" val="cmd vert.center yz">
+        <atom type="Label">YZ</atom>
+      </list>
+    </hash>
+  </atom>
+</configuration>

--- a/Configs/GooseBig's Selection Set Pies.CFG
+++ b/Configs/GooseBig's Selection Set Pies.CFG
@@ -1,0 +1,103 @@
+<?xml version="1.0"?>
+<configuration>
+  <atom type="Attributes">
+    <hash type="Sheet" key="74633695160:sheet">
+      <atom type="Label">Selection Set Pie</atom>
+      <atom type="Desc">Hotkey = ctrl-w (registered in GooseBig's InputRemapping.CFG)
+
+#this hotkey conflict with QQ's default setting</atom>
+      <atom type="Style">pie</atom>
+      <atom type="EditorColor">786432</atom>
+      <atom type="Group">piemenus</atom>
+      <list type="Control" val="cmd select.editSet TempSet add">
+        <atom type="Label">Add to TempSet</atom>
+      </list>
+      <list type="Control" val="cmd select.useSet TempSet select">
+        <atom type="Label">Select TempSet</atom>
+      </list>
+      <list type="Control" val="cmd select.editSet TempSet remove {}">
+        <atom type="Label">Remove from TempSet</atom>
+      </list>
+      <list type="Control" val="cmd attr.formPopover {17252695221:sheet}">
+        <atom type="Label">UV Seam Set...</atom>
+      </list>
+      <list type="Control" val="cmd attr.formPopover {23997695182:sheet}">
+        <atom type="Label">Edit Selection Sets...</atom>
+      </list>
+      <list type="Control" val="cmd layout.createOrClose Info-stats Info-stats_layout true &quot;Tool Bar&quot; width:320 height:600 persistent:false style:popoverRollOff">
+        <atom type="Label">Info Window Popover</atom>
+      </list>
+      <list type="Control" val="cmd select.clearSet TempSet">
+        <atom type="Label">Clear TempSet</atom>
+      </list>
+      <list type="Control" val="cmd select.useSet TempSet deselect">
+        <atom type="Label">Deselect TempSet</atom>
+      </list>
+      <list type="Control" val="cmd select.editSet TempSet remove {}">
+        <atom type="Label">Delete TempSet</atom>
+      </list>
+    </hash>
+    <hash type="Sheet" key="17252695221:sheet">
+      <atom type="Label">UV Seam Selection Set Pie</atom>
+      <atom type="Style">pie</atom>
+      <atom type="EditorColor">65536</atom>
+      <atom type="Group">piemenus</atom>
+      <list type="Control" val="cmd select.editSet &quot;UV Seam&quot; add">
+        <atom type="Label">Add to UV Seam</atom>
+      </list>
+      <list type="Control" val="cmd select.useSet &quot;UV Seam&quot; select">
+        <atom type="Label">Select UV Seam</atom>
+      </list>
+      <list type="Control" val="cmd select.editSet &quot;UV Seam&quot; remove {}">
+        <atom type="Label">Remove from UV Seam</atom>
+      </list>
+      <list type="Control" val="cmd select.useSet &quot;UV Seam&quot; replace">
+        <atom type="Label">Replace with UV Seam</atom>
+      </list>
+      <list type="Control" val="div ">
+        <atom type="Alignment">full</atom>
+        <atom type="Hash">50626695803:control</atom>
+      </list>
+      <list type="Control" val="cmd select.editSet &quot;UV Seam&quot; remove {}">
+        <atom type="Label">Delete UV Seam</atom>
+      </list>
+      <list type="Control" val="cmd select.clearSet &quot;UV Seam&quot;">
+        <atom type="Label">Clear UV Seam</atom>
+      </list>
+      <list type="Control" val="cmd select.useSet &quot;UV Seam&quot; deselect">
+        <atom type="Label">Deselect UV Seam</atom>
+      </list>
+    </hash>
+    <hash type="Sheet" key="23997695182:sheet">
+      <atom type="Label">Edit Selection Set Pie</atom>
+      <atom type="Style">pie</atom>
+      <atom type="EditorColor">65536</atom>
+      <atom type="Group">piemenus</atom>
+      <list type="Control" val="cmd select.editSet">
+        <atom type="Label">Assign Selection Set...</atom>
+      </list>
+      <list type="Control" val="div ">
+        <atom type="Alignment">full</atom>
+        <atom type="Hash">65056695334:control</atom>
+      </list>
+      <list type="Control" val="cmd select.useSet">
+        <atom type="Label">Use Selection Set...</atom>
+      </list>
+      <list type="Control" val="div ">
+        <atom type="Alignment">full</atom>
+        <atom type="Hash">63801695354:control</atom>
+      </list>
+      <list type="Control" val="div ">
+        <atom type="Alignment">full</atom>
+        <atom type="Hash">96146695351:control</atom>
+      </list>
+      <list type="Control" val="div ">
+        <atom type="Alignment">full</atom>
+        <atom type="Hash">31405695347:control</atom>
+      </list>
+      <list type="Control" val="cmd select.deleteSet">
+        <atom type="Label">Delete Selection Set...</atom>
+      </list>
+    </hash>
+  </atom>
+</configuration>

--- a/Configs/Sen's Random Selector.CFG
+++ b/Configs/Sen's Random Selector.CFG
@@ -1,0 +1,38 @@
+<?xml version="1.0"?>
+<configuration>
+  <atom type="Attributes">
+    <hash type="Sheet" key="17680715101:sheet">
+      <atom type="Label">Sen's Random Selector</atom>
+      <atom type="Desc">Hotkey = alt-s (registered in GooseBig's InputRemapping.CFG)
+
+Require &quot;senemodo&quot; installed</atom>
+      <atom type="Style">pie</atom>
+      <atom type="EditorColor">786432</atom>
+      <atom type="Group">piemenus</atom>
+      <list type="Control" val="cmd @randomSel_new.pl">
+        <atom type="Label">Select Elems</atom>
+      </list>
+      <list type="Control" val="cmd @randomSel_new.pl part">
+        <atom type="Label">Select Parts</atom>
+      </list>
+      <list type="Control" val="cmd @randomSel_new.pl mesh">
+        <atom type="Label">Select Meshes</atom>
+      </list>
+      <list type="Control" val="cmd @randomSel_new.pl uvIsland">
+        <atom type="Label">Select UV Islands</atom>
+      </list>
+      <list type="Control" val="cmd @randomSel_new.pl deselect">
+        <atom type="Label">Deselect Elems</atom>
+      </list>
+      <list type="Control" val="cmd @randomSel_new.pl deselect uvIsland">
+        <atom type="Label">Deselect UV Islands</atom>
+      </list>
+      <list type="Control" val="cmd @randomSel_new.pl deselect mesh">
+        <atom type="Label">Deselect Meshes</atom>
+      </list>
+      <list type="Control" val="cmd @randomSel_new.pl deselect part">
+        <atom type="Label">Deselect Parts</atom>
+      </list>
+    </hash>
+  </atom>
+</configuration>

--- a/Configs/Sen's Script and GUI toolbar icon.CFG
+++ b/Configs/Sen's Script and GUI toolbar icon.CFG
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<configuration>
+  <atom type="Attributes">
+    <hash type="Sheet" key="frm_ModoModesToolbar:sheet">
+      <atom type="Label">modo modes toolbar</atom>
+      <atom type="ShowLabel">0</atom>
+      <atom type="Layout">htoolbar</atom>
+      <atom type="Justification">left</atom>
+      <atom type="IconMode">both</atom>
+      <atom type="IconSize">small</atom>
+      <atom type="Group">modo 'modes' toolbars</atom>
+      <list type="Control" val="cmd attr.formPopover {senemodokit:sheet}">
+        <atom type="Label">Sen</atom>
+        <atom type="Tooltip">Open Sen's Script GUI</atom>
+      <atom type="IconImage">D:[Luxology Modo]/[Script]/senemodo/icons/S.png</atom>
+        <atom type="EditorColor">red</atom>
+      </list>
+    </hash>
+  </atom>
+</configuration>

--- a/Configs/Viewports.CFG
+++ b/Configs/Viewports.CFG
@@ -1,0 +1,40 @@
+<?xml version="1.0"?>
+<configuration>
+  <atom type="Attributes">
+    <hash type="Sheet" key="67300786789:sheet">
+      <atom type="Label">Viewports</atom>
+      <atom type="Style">pie</atom>
+      <atom type="IconMode">both</atom>
+      <atom type="IconSize">large</atom>
+      <atom type="EditorColor">786432</atom>
+      <atom type="Group">piemenus</atom>
+      <list type="Control" val="cmd attr.formPopover {itemprops:general}">
+        <atom type="Label">Item Properties Popover</atom>
+      </list>
+      <list type="Control" val="cmd layout.createOrClose cookie:Color layout:{Color_layout} title:{Color Picker} width:200 height:200 persistent:0 style:popoverRollOff open:?">
+        <atom type="Label">Color</atom>
+      <atom type="IconImage">resource:colorpicker32.tga</atom>
+      </list>
+      <list type="Control" val="cmd layout.createOrClose cookie:Tools layout:{modo Tools_layout} title:{Tool Bar} width:200 height:600 persistent:0 style:popoverRollOffr open:?">
+        <atom type="Label">Tools</atom>
+      <atom type="IconImage">resource:Tools32.png</atom>
+      </list>
+      <list type="Control" val="cmd layout.createOrClose cookie:{Item List} layout:{ItemList_layout} title:{Tool Bar} width:300 height:400 persistent:0 style:popoverRollOff open:?">
+        <atom type="Label">Item List</atom>
+      <atom type="IconImage">resource:ItemList32.tga</atom>
+      </list>
+      <list type="Control" val="cmd layout.createOrClose cookie:ToolPipe open:? layout:{ToolPipe Palette} title:{Tool Pipe} width:350 height:300 persistent:1 style:palette">
+        <atom type="Label">Tool Pipe</atom>
+      </list>
+      <list type="Control" val="cmd layout.createOrClose cookie:{UV Editor} layout:{UV Editor_layout} title:{Tool Bar} width:800 height:600 persistent:0 style:popover open:?">
+        <atom type="Label">UV Editor</atom>
+      </list>
+      <list type="Control" val="cmd layout.createOrClose cookie:{Info-stats} layout:{Info-stats_layout} title:{Tool Bar} width:800 height:600 persistent:0 style:popoverRollOff open:?">
+        <atom type="Label">Info &amp; Stats</atom>
+      </list>
+      <list type="Control" val="cmd layout.createOrClose cookie:{Graph Editor Palette} layout:{Graph Editor Palette_layout} title:{Graph Ed} width:1010 height:325 persistent:0  style:popoverRollOff open:?">
+        <atom type="Label">Graph Editor</atom>
+      </list>
+    </hash>
+  </atom>
+</configuration>


### PR DESCRIPTION
This is about how to make Modo modeling experience smoother.

These are my Modo config that helps me speed up my modeling process.

If you would like to know more about how to customize you Modo, my config set is a good point to start, in stead of head first to Modo's official documents. You can apply these files, guess how they work, then read some documents with your questions. It may be more efficient this way.

Also, you can check Warren Marshall's video tips about Modo config (https://www.youtube.com/watch?v=wv3DC_GggFw).

Some customizations requires Etereae's kits and Seneca's scripts, you can get them from links below
http://www.etereaestudios.com/docs_html/general_index_htm/resources.htm
http://dl.dropbox.com/u/1615250/senemodo.zip
some information about Seneca's scripts: http://www.indigosm.com/modoscripts.htm

### **About these config files:**
**_GooseBig's InputRemapping.CFG_**, this file contains all my key remapping. Most of them are context-sensitive tool specific shortcuts, like while you are using bevel tool the 'A' and 'D' become decrease and increase bevel levels. The others are customized pie menu hotkeys and some other popovers. If you want to change hotkeys of my pie menus, you need to edit this file.

**_3D gang Disable.CFG_**, disabled a bunch of 3D Gangs of primitives tools. I never used them once, and they take a lot of the UI space if you don't have a big enough monitor you will have to click the ">>" icon to find the 'Apply' button to make you primitive. I also moved the 'Apply' button to the top.

**_Action Center Pie.CFG_**, modified Modo's 'Action Center' pie menu. Added 'Axis' pie menu as a sub at 6 o'clock direction. And you can easily adjust it in the 'Form Editor'. So you don't need to select Action Center from the menu above. A lot of hotkeys will be freed from you left-hand side keyboard; Action Center shortcuts took a lot of useful keys, you can use them elsewhere now. Hotkey is 'Alt + A'.

**_Background Mesh Display Pie_Fixed.CFG_**, fixed the 'Same as Active' option can turn those mesh items back to 'Inactive'.

**_Falloff Pie.CFG, Viewports.CFG_**, a pie menu include all falloff type except 'Image Falloff'. Bind to 'Shift + F'.

**_ETEREA Primitives Enhanced.CFG_**, 'ETEREA Primitives' kit required. Actually, you need to use this file to replace the 'eterea_primitives.CFG' file or use the code in this config to replace the code in 'eterea_primitives.CFG' file. This config makes you can active primitives tools by using 'ETEREA Primitives'.

**_GooseBig's 3D Context Modeling Operation Menu.CFG_**, basically the same thing as 'Modeling Operations' menu while you right click on a 3D element. This only makes it quicker and cleaner. I bind this on the 'Space bar'.

**_GooseBig's Duplicate and Instance Pies.CFG_**, two pie menus for duplicate and instance clone. 'Alt + D' is the duplicate pie, instance pie binds to 'Ctrl + Alt +D'.

**_GooseBig's Macros.CFG_**, macros I made for these pie menus.

**_GooseBig's Modeling Operation Pie.CFG_**, the most important pie menu for myself, helps me do thing quickly. eg. merge vertices without popping up dialog window need you to confirm. Options pretty self-explained, w/o means "without popups". Options with '...' means it opens a sub pie menu. Bind to 'Shift + Space'.

**_GooseBig's Selection Set Pies.CFG_**, quick create and edit a selection set and a sub pie menu for creating and editing a selection set called 'UV seam'. Bind to 'Alt + W'.

**_Sen's Random Selector.CFG_**, quick access Seneca's random selection scripts. 'Alt + S'.

**_Sen's Script and GUI toolbar icon.CFG_**, simply added a button on the 'modo modes toolbar' for 'Sen_Scripts and Guis' palette.

### **How to install**:
Modo menu bar "System/Open User Configs Folder" open the folder "C:\Users\USERNAME\AppData\Roaming\Luxology\Configs", and just put these files in.